### PR TITLE
Use SWO for logging

### DIFF
--- a/CNC_Controller/App/Inc/Services/Log/log_service.h
+++ b/CNC_Controller/App/Inc/Services/Log/log_service.h
@@ -1,4 +1,4 @@
-// Non-interruptive USB (USART1 VCP) logging service
+// Non-interruptive SWO logging service
 #pragma once
 
 #include <stdint.h>

--- a/CNC_Controller/App/Src/Services/Log/log_service.c
+++ b/CNC_Controller/App/Src/Services/Log/log_service.c
@@ -3,7 +3,7 @@
 
 #include <string.h>
 #include <stdio.h>
-#include "usart.h"
+#include "stm32l4xx_hal.h" // for ITM_SendChar
 
 #ifndef LOG_BUF_SZ
 #define LOG_BUF_SZ 1024u
@@ -17,9 +17,6 @@ static volatile log_mode_t s_mode = LOG_MODE_CONCISE;
 static uint8_t s_buf[LOG_BUF_SZ];
 static volatile uint16_t s_head = 0; // write index
 static volatile uint16_t s_tail = 0; // read index
-static volatile uint8_t s_tx_busy = 0;
-static uint8_t s_tx_buf[LOG_CHUNK_MAX];
-static uint16_t s_tx_len = 0;
 
 static inline uint16_t rb_count(void){
     uint16_t h = s_head, t = s_tail;
@@ -49,7 +46,17 @@ void log_service_init(void){
     s_enabled = LOG_DEFAULT_ENABLED;
     s_mode = LOG_DEFAULT_MODE;
     s_head = s_tail = 0;
-    s_tx_busy = 0;
+
+    /* Enable trace and configure SWO for ITM output */
+    DBGMCU->CR |= DBGMCU_CR_TRACE_IOEN;
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+    ITM->LAR = 0xC5ACCE55;           /* Unlock ITM */
+    TPI->SPPR = 2;                   /* NRZ/USART encoding */
+    TPI->ACPR = (HAL_RCC_GetHCLKFreq() / 2000000U) - 1U; /* 2 MHz SWO */
+    TPI->FFCR = 0x100U;              /* Formatter: flush on TPIU disable */
+    ITM->TPR = 0U;                   /* All stimulus ports accessible */
+    ITM->TCR = ITM_TCR_ITMENA_Msk | ITM_TCR_SWOENA_Msk; /* Enable ITM + SWO */
+    ITM->TER = 1U;                   /* Enable stimulus port 0 */
 }
 
 void log_set_enabled(int enabled){ s_enabled = (enabled != 0); }
@@ -80,28 +87,18 @@ void log_event_names(const char* service_name, const char* state_name, const cha
 
 void log_poll(void){
     if(!s_enabled) return;
-    if(s_tx_busy) return; // wait for current IT transfer to complete
     uint16_t cnt = rb_count();
     if(!cnt) return;
     uint16_t n = (cnt > LOG_CHUNK_MAX) ? LOG_CHUNK_MAX : cnt;
-    uint16_t first = (uint16_t)((s_head >= s_tail) ? (n) : (uint16_t)(LOG_BUF_SZ - s_tail));
-    if(first > n) first = n;
-    memcpy(s_tx_buf, &s_buf[s_tail], first);
-    if(first < n){
-        memcpy(s_tx_buf + first, &s_buf[0], n - first);
-    }
-    if(HAL_UART_Transmit_IT(&huart1, s_tx_buf, (uint16_t)n) == HAL_OK){
-        s_tail = (uint16_t)((s_tail + n) % LOG_BUF_SZ);
-        s_tx_len = n;
-        s_tx_busy = 1;
+    for(uint16_t i = 0; i < n; ++i){
+        ITM_SendChar(s_buf[s_tail]);
+        s_tail = (uint16_t)((s_tail + 1) % LOG_BUF_SZ);
     }
 }
 
-// Keep ISR work minimal; just clear busy so app can schedule next chunk.
-void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart){
-    if(huart && huart->Instance == USART1){
-        s_tx_busy = 0;
-    }
+int __io_putchar(int ch){
+    ITM_SendChar((uint32_t)ch);
+    return ch;
 }
 
 #endif // LOG_ENABLE

--- a/CNC_Controller/Core/Src/main.c
+++ b/CNC_Controller/Core/Src/main.c
@@ -59,19 +59,7 @@ void SystemClock_Config(void);
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
-
-int _write(int fd, char *ptr, int len) {
-    HAL_StatusTypeDef hstatus;
-
-    if (fd == 1 || fd == 2) {
-      hstatus = HAL_UART_Transmit(&huart1, (uint8_t *) ptr, len, HAL_MAX_DELAY);
-      if (hstatus == HAL_OK)
-        return len;
-      else
-        return -1;
-    }
-    return -1;
-}
+/* Redirects are handled by __io_putchar in log_service.c */
 /* USER CODE END 0 */
 
 /**
@@ -107,12 +95,14 @@ int main(void) {
 	MX_TIM6_Init();
 	MX_TIM2_Init();
 	MX_TIM5_Init();
-	MX_TIM7_Init();
-	MX_TIM3_Init();
-	MX_USART1_UART_Init();
+        MX_TIM7_Init();
+        MX_TIM3_Init();
+        MX_USART1_UART_Init();
     /* USER CODE BEGIN 2 */
+        /* Disable stdio buffering so prints appear immediately on SWO */
+        setvbuf(stdout, NULL, _IONBF, 0);
 
-	app_init();
+        app_init();
 
 	/* USER CODE END 2 */
 


### PR DESCRIPTION
## Summary
- configure ITM/TPIU and DBGMCU registers per AN4989 to stream logs over SWO
- disable stdio buffering so `printf` reaches the SWO console immediately

## Testing
- `make -C CNC_Controller/Debug` *(fails: multiple target patterns)*
- `cmake -S CNC_Controller/App/Tests -B build/tests`
- `cmake --build build/tests`
- `ctest --test-dir build/tests`


------
https://chatgpt.com/codex/tasks/task_e_68c742592da08326bc733866fc027616