### PR TITLE
Fix log UART retargeting via log service

### DIFF
--- a/CNC_Controller/Core/Src/main.c
+++ b/CNC_Controller/Core/Src/main.c
@@ -171,18 +171,6 @@ void SystemClock_Config(void)
 }
 
 /* USER CODE BEGIN 4 */
-
-int _write(int fd, char *ptr, int len) {
-    HAL_StatusTypeDef hstatus;
-    if (fd == 1 || fd == 2) {
-      hstatus = HAL_UART_Transmit(&huart1, (uint8_t *) ptr, len, HAL_MAX_DELAY);
-      if (hstatus == HAL_OK)
-        return len;
-      else
-        return -1;
-    }
-    return -1;
-}
 /* USER CODE END 4 */
 
 /**


### PR DESCRIPTION
## Summary
- route `_write` through the logging ring buffer so `printf` and log macros share the same UART backend
- guard the poller against an uninitialized USART instance and drop the blocking retarget from `main.c`

## Testing
- not run (hardware-specific toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8a6dbdf7c8326bb0ca03c6faf7cf8