### PR TITLE
Refactor board configuration into App module

### DIFF
--- a/CNC_Controller/App/Inc/board_config.h
+++ b/CNC_Controller/App/Inc/board_config.h
@@ -1,0 +1,54 @@
+#ifndef BOARD_CONFIG_H
+#define BOARD_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "stm32l4xx_hal.h"
+
+/**
+ * @brief Applies the motion-controller specific GPIO configuration.
+ *
+ * This helper programs STEP/DIR/ENABLE outputs and arms the E-STOP/PROX inputs
+ * with external interrupts after the CubeMX generated defaults are in place.
+ */
+void board_config_apply_motion_gpio(void);
+
+/**
+ * @brief Ensures encoder timers run in quadrature (TI12) mode.
+ *
+ * Call once after the CubeMX initialisation to upgrade TIM2/TIM3/TIM5 to the
+ * X4 counting scheme required by the CNC encoders.
+ */
+void board_config_force_encoder_quadrature(void);
+
+/**
+ * @brief Remaps the Z axis encoder inputs to GPIOC pins.
+ *
+ * The firmware expects TIM3 channels on PC6/PC7 to match the wiring harness,
+ * so this helper reconfigures the alternate function mapping accordingly.
+ */
+void board_config_remap_tim3_encoder_pins(void);
+
+/**
+ * @brief Applies the interrupt priority hierarchy defined for the CNC project.
+ *
+ * This sets NVIC levels for safety EXTI lines, motion timers, SPI DMA and the
+ * diagnostic USART to honour the deterministic schedule documented in the README.
+ */
+void board_config_apply_interrupt_priorities(void);
+
+/**
+ * @brief Applies the SPI1 DMA priority/shape used by the CNC transport.
+ *
+ * Call once after the CubeMX initialisation to rebuild the RX channel with high
+ * priority (circular) and the TX channel with normal priority (one-shot).
+ */
+void board_config_apply_spi_dma_profile(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_CONFIG_H */

--- a/CNC_Controller/App/Inc/board_config.h
+++ b/CNC_Controller/App/Inc/board_config.h
@@ -8,42 +8,52 @@ extern "C" {
 #include "stm32l4xx_hal.h"
 
 /**
- * @brief Applies the motion-controller specific GPIO configuration.
+ * @brief Aplica o mapeamento de GPIO definido para o controlador CNC.
  *
- * This helper programs STEP/DIR/ENABLE outputs and arms the E-STOP/PROX inputs
- * with external interrupts after the CubeMX generated defaults are in place.
+ * Este helper recompõe todos os pinos sensíveis após a inicialização gerada
+ * pelo CubeMX: configura STEP/DIR/ENABLE com *push-pull* em alta velocidade,
+ * grava o nível seguro de repouso para cada saída e arma as entradas de
+ * segurança (E-STOP e sensores de proximidade) com interrupção externa.
+ * Deve ser chamado logo após `MX_GPIO_Init()` para garantir que nenhum pino
+ * permaneça com direção ou *pull* incorretos enquanto os drivers são energizados.
  */
 void board_config_apply_motion_gpio(void);
 
 /**
- * @brief Ensures encoder timers run in quadrature (TI12) mode.
+ * @brief Força os *timers* de encoder a operar em modo de quadratura TI12 (X4).
  *
- * Call once after the CubeMX initialisation to upgrade TIM2/TIM3/TIM5 to the
- * X4 counting scheme required by the CNC encoders.
+ * CubeMX gera os contadores no modo TI1 por padrão, o que perderia metade dos
+ * flancos. Esta rotina reconfigura TIM2/TIM3/TIM5 para capturar ambos os
+ * canais do encoder e habilita a contagem em quatro vezes a resolução.
  */
 void board_config_force_encoder_quadrature(void);
 
 /**
- * @brief Remaps the Z axis encoder inputs to GPIOC pins.
+ * @brief Remapeia os sinais do encoder do eixo Z para os pinos PC6/PC7.
  *
- * The firmware expects TIM3 channels on PC6/PC7 to match the wiring harness,
- * so this helper reconfigures the alternate function mapping accordingly.
+ * O chicote do controlador leva TIM3_CH1/CH2 até o conector em GPIOC, mas o
+ * CubeMX ainda prende os canais a PE3/PE4. Esta função libera os pinos
+ * originais e refaz a configuração de *alternate function* em PC6/PC7.
  */
 void board_config_remap_tim3_encoder_pins(void);
 
 /**
- * @brief Applies the interrupt priority hierarchy defined for the CNC project.
+ * @brief Programa a hierarquia de prioridades de interrupção usada pelo CNC.
  *
- * This sets NVIC levels for safety EXTI lines, motion timers, SPI DMA and the
- * diagnostic USART to honour the deterministic schedule documented in the README.
+ * Define os níveis do NVIC (Nested Vectored Interrupt Controller) para que as
+ * rotinas críticas respeitem a ordem descrita no README: EXTI de segurança no
+ * topo, seguido do laço de passos (TIM6), DMA de SPI, laço de controle (TIM7)
+ * e, por último, os periféricos de diagnóstico como a USART.
  */
 void board_config_apply_interrupt_priorities(void);
 
 /**
- * @brief Applies the SPI1 DMA priority/shape used by the CNC transport.
+ * @brief Ajusta o perfil de DMA do SPI1 para o transporte mestre-escravo.
  *
- * Call once after the CubeMX initialisation to rebuild the RX channel with high
- * priority (circular) and the TX channel with normal priority (one-shot).
+ * Reconstrói os canais gerados pelo CubeMX para que a recepção opere em modo
+ * circular com prioridade alta (evitando *overrun* de comandos) e a transmissão
+ * use prioridade normal em modo *one-shot*, alinhada ao escoamento assíncrono
+ * do `router` do aplicativo.
  */
 void board_config_apply_spi_dma_profile(void);
 

--- a/CNC_Controller/App/Src/board_config.c
+++ b/CNC_Controller/App/Src/board_config.c
@@ -1,0 +1,161 @@
+#include "board_config.h"
+
+#include "main.h"
+#include "gpio.h"
+#include "tim.h"
+#include "spi.h"
+#include "usart.h"
+
+/** Local helper to configure the three encoder timers in TI12 mode. */
+static void configure_encoder_timer(TIM_HandleTypeDef *htim)
+{
+    TIM_Encoder_InitTypeDef config = {0};
+    TIM_MasterConfigTypeDef master = {0};
+
+    config.EncoderMode = TIM_ENCODERMODE_TI12;
+    config.IC1Polarity = TIM_ICPOLARITY_RISING;
+    config.IC1Selection = TIM_ICSELECTION_DIRECTTI;
+    config.IC1Prescaler = TIM_ICPSC_DIV1;
+    config.IC1Filter = 0;
+    config.IC2Polarity = TIM_ICPOLARITY_RISING;
+    config.IC2Selection = TIM_ICSELECTION_DIRECTTI;
+    config.IC2Prescaler = TIM_ICPSC_DIV1;
+    config.IC2Filter = 0;
+
+    if (HAL_TIM_Encoder_Init(htim, &config) != HAL_OK)
+    {
+        Error_Handler();
+    }
+
+    master.MasterOutputTrigger = TIM_TRGO_RESET;
+    master.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_TIMEx_MasterConfigSynchronization(htim, &master) != HAL_OK)
+    {
+        Error_Handler();
+    }
+}
+
+/** Local helper to configure one bank of STEP/DIR/ENABLE outputs. */
+static void configure_output(GPIO_TypeDef *port, uint32_t pins, uint32_t speed)
+{
+    GPIO_InitTypeDef init = {0};
+    init.Pin = pins;
+    init.Mode = GPIO_MODE_OUTPUT_PP;
+    init.Pull = GPIO_NOPULL;
+    init.Speed = speed;
+    HAL_GPIO_Init(port, &init);
+}
+
+void board_config_apply_motion_gpio(void)
+{
+    GPIO_InitTypeDef init = {0};
+
+    /* Output configuration for motion control pins */
+    configure_output(GPIOB, GPIO_PIN_4 | GPIO_PIN_0 | GPIO_PIN_1, GPIO_SPEED_FREQ_VERY_HIGH);
+    configure_output(GPIOB, GPIO_PIN_2, GPIO_SPEED_FREQ_VERY_HIGH);
+    configure_output(GPIOA, GPIO_PIN_3 | GPIO_PIN_2, GPIO_SPEED_FREQ_VERY_HIGH);
+    configure_output(GPIOC, GPIO_PIN_4 | GPIO_PIN_5, GPIO_SPEED_FREQ_LOW);
+    configure_output(GPIOA, GPIO_PIN_8, GPIO_SPEED_FREQ_LOW);
+
+    /* STEP/DIR/ENABLE default states */
+    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_4 | GPIO_PIN_2 | GPIO_PIN_0 | GPIO_PIN_1, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(GPIOA, GPIO_PIN_3 | GPIO_PIN_2, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_4 | GPIO_PIN_5, GPIO_PIN_SET);
+    HAL_GPIO_WritePin(GPIOA, GPIO_PIN_8, GPIO_PIN_SET);
+
+    /* Safety inputs (E-STOP / proximity) */
+    init.Mode = GPIO_MODE_IT_RISING_FALLING;
+    init.Pull = GPIO_PULLUP;
+
+    init.Pin = GPIO_PIN_0 | GPIO_PIN_1 | GPIO_PIN_2;
+    HAL_GPIO_Init(GPIOC, &init);
+
+    init.Pin = GPIO_PIN_13;
+    HAL_GPIO_Init(GPIOC, &init);
+}
+
+void board_config_force_encoder_quadrature(void)
+{
+    configure_encoder_timer(&htim2);
+    configure_encoder_timer(&htim3);
+    configure_encoder_timer(&htim5);
+}
+
+void board_config_remap_tim3_encoder_pins(void)
+{
+    GPIO_InitTypeDef init = {0};
+
+    /* Release the default CubeMX pins and map the encoder to PC6/PC7. */
+    HAL_GPIO_DeInit(GPIOE, GPIO_PIN_3 | GPIO_PIN_4);
+
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+
+    init.Pin = GPIO_PIN_6 | GPIO_PIN_7;
+    init.Mode = GPIO_MODE_AF_PP;
+    init.Pull = GPIO_NOPULL;
+    init.Speed = GPIO_SPEED_FREQ_LOW;
+    init.Alternate = GPIO_AF2_TIM3;
+    HAL_GPIO_Init(GPIOC, &init);
+}
+
+void board_config_apply_interrupt_priorities(void)
+{
+    /* Safety EXTI inputs outrank everything. */
+    HAL_NVIC_SetPriority(EXTI0_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(EXTI0_IRQn);
+
+    HAL_NVIC_SetPriority(EXTI1_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(EXTI1_IRQn);
+
+    HAL_NVIC_SetPriority(EXTI2_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(EXTI2_IRQn);
+
+    HAL_NVIC_SetPriority(EXTI15_10_IRQn, 0, 0);
+    HAL_NVIC_EnableIRQ(EXTI15_10_IRQn);
+
+    /* Motion core timing */
+    HAL_NVIC_SetPriority(TIM6_DAC_IRQn, 1, 0);
+    HAL_NVIC_EnableIRQ(TIM6_DAC_IRQn);
+
+    HAL_NVIC_SetPriority(DMA1_Channel2_IRQn, 2, 0);
+    HAL_NVIC_EnableIRQ(DMA1_Channel2_IRQn);
+
+    HAL_NVIC_SetPriority(DMA1_Channel3_IRQn, 2, 0);
+    HAL_NVIC_EnableIRQ(DMA1_Channel3_IRQn);
+
+    HAL_NVIC_SetPriority(TIM7_IRQn, 3, 0);
+    HAL_NVIC_EnableIRQ(TIM7_IRQn);
+
+    HAL_NVIC_SetPriority(USART1_IRQn, 4, 0);
+    HAL_NVIC_EnableIRQ(USART1_IRQn);
+
+    HAL_NVIC_SetPriority(SPI1_IRQn, 5, 0);
+    HAL_NVIC_EnableIRQ(SPI1_IRQn);
+}
+
+void board_config_apply_spi_dma_profile(void)
+{
+    if (HAL_DMA_DeInit(&hdma_spi1_rx) != HAL_OK)
+    {
+        Error_Handler();
+    }
+    hdma_spi1_rx.Init.Priority = DMA_PRIORITY_HIGH;
+    hdma_spi1_rx.Init.Mode = DMA_CIRCULAR;
+    if (HAL_DMA_Init(&hdma_spi1_rx) != HAL_OK)
+    {
+        Error_Handler();
+    }
+    __HAL_LINKDMA(&hspi1, hdmarx, hdma_spi1_rx);
+
+    if (HAL_DMA_DeInit(&hdma_spi1_tx) != HAL_OK)
+    {
+        Error_Handler();
+    }
+    hdma_spi1_tx.Init.Priority = DMA_PRIORITY_LOW;
+    hdma_spi1_tx.Init.Mode = DMA_NORMAL;
+    if (HAL_DMA_Init(&hdma_spi1_tx) != HAL_OK)
+    {
+        Error_Handler();
+    }
+    __HAL_LINKDMA(&hspi1, hdmatx, hdma_spi1_tx);
+}

--- a/CNC_Controller/Core/Src/main.c
+++ b/CNC_Controller/Core/Src/main.c
@@ -27,6 +27,7 @@
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
 // #include "app.h" // (comentado a pedido: não usar app.h)
+#include "board_config.h"
 #include "Services/Log/log_service.h"
 #include "Protocol/frame_defs.h"
 #include <stdio.h>
@@ -104,6 +105,11 @@ int main(void)
   MX_TIM3_Init();
   MX_USART1_UART_Init();
   /* USER CODE BEGIN 2 */
+    board_config_apply_motion_gpio();
+    board_config_remap_tim3_encoder_pins();
+    board_config_force_encoder_quadrature();
+    board_config_apply_interrupt_priorities();
+    board_config_apply_spi_dma_profile();
 	// app_init(); // (comentado a pedido)
 
 	// Enfileira diretamente no SPI (slave) o frame de teste "hello".

--- a/CNC_Controller/Core/Src/stm32l4xx_it.c
+++ b/CNC_Controller/Core/Src/stm32l4xx_it.c
@@ -272,5 +272,23 @@ void TIM7_IRQHandler(void)
 }
 
 /* USER CODE BEGIN 1 */
+void EXTI0_IRQHandler(void)
+{
+  HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_0);
+}
 
+void EXTI1_IRQHandler(void)
+{
+  HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_1);
+}
+
+void EXTI2_IRQHandler(void)
+{
+  HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_2);
+}
+
+void EXTI15_10_IRQHandler(void)
+{
+  HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_13);
+}
 /* USER CODE END 1 */

--- a/CNC_Controller/Debug/App/Src/subdir.mk
+++ b/CNC_Controller/Debug/App/Src/subdir.mk
@@ -5,13 +5,16 @@
 
 # Add inputs and outputs from these tool invocations to the build variables 
 C_SRCS += \
-../App/Src/app.c 
+../App/Src/app.c \
+../App/Src/board_config.c 
 
 OBJS += \
-./App/Src/app.o 
+./App/Src/app.o \
+./App/Src/board_config.o 
 
 C_DEPS += \
-./App/Src/app.d 
+./App/Src/app.d \
+./App/Src/board_config.d 
 
 
 # Each subdirectory must supply rules for building sources it contributes
@@ -21,7 +24,8 @@ App/Src/%.o App/Src/%.su App/Src/%.cyclo: ../App/Src/%.c App/Src/subdir.mk
 clean: clean-App-2f-Src
 
 clean-App-2f-Src:
-	-$(RM) ./App/Src/app.cyclo ./App/Src/app.d ./App/Src/app.o ./App/Src/app.su
+	-$(RM) ./App/Src/app.cyclo ./App/Src/app.d ./App/Src/app.o ./App/Src/app.su \
+	       ./App/Src/board_config.cyclo ./App/Src/board_config.d ./App/Src/board_config.o ./App/Src/board_config.su
 
 .PHONY: clean-App-2f-Src
 

--- a/CNC_Controller/Debug/objects.list
+++ b/CNC_Controller/Debug/objects.list
@@ -24,6 +24,7 @@
 "./App/Src/Services/Test/test_spi_service.o"
 "./App/Src/Services/service_adapters.o"
 "./App/Src/app.o"
+"./App/Src/board_config.o"
 "./Core/Src/dma.o"
 "./Core/Src/gpio.o"
 "./Core/Src/main.o"


### PR DESCRIPTION
## Summary
- add an App-level board_config module that applies the CNC GPIO, encoder, interrupt and SPI DMA tweaks after CubeMX init
- hook the new helpers from main.c and move EXTI handlers into the user section so Core files remain close to the generator output
- update the Debug make fragments so the new board_config.c object is built and linked

## Testing
- `make -C CNC_Controller/Debug` *(fails: makefile expects Windows-style linker paths and aborts with "multiple target patterns")*

------
https://chatgpt.com/codex/tasks/task_e_68c9f8fd7a50832687342855e1cd3015