### PR TITLE
Use SPI TxRx DMA with handshake buffer

### DIFF
--- a/CNC_Controller/App/Inc/app.h
+++ b/CNC_Controller/App/Inc/app.h
@@ -14,6 +14,6 @@ void app_poll(void);
 int app_resp_push(const uint8_t *frame, uint32_t len);
 
 // Hooks invoked from HAL callbacks (defined in main.c)
-void app_on_spi_rx_half_complete(SPI_HandleTypeDef *h);
-void app_on_spi_rx_complete(SPI_HandleTypeDef *h);
+void app_on_spi_txrx_half_complete(SPI_HandleTypeDef *h);
+void app_on_spi_txrx_complete(SPI_HandleTypeDef *h);
 void app_on_spi_tx_complete(SPI_HandleTypeDef *h);

--- a/CNC_Controller/App/Src/app.c
+++ b/CNC_Controller/App/Src/app.c
@@ -1,81 +1,118 @@
 #include <string.h>
 #include "spi.h"
 #include "app.h"
+#include "Protocol/frame_defs.h"
 #include "Protocol/router.h"
 #include "Services/service_adapters.h"
 #include "Services/Led/led_service.h"
 #include "Services/Log/log_service.h"
 #include "Services/Test/test_spi_service.h"
 
-// Router + response queue
+#define APP_SPI_MAX_REQUEST_LEN    42u
+#define APP_SPI_HANDSHAKE_BITS     8u
+#define APP_SPI_HANDSHAKE_BYTES    (APP_SPI_HANDSHAKE_BITS / 8u)
+#define APP_SPI_DMA_BUF_LEN        (APP_SPI_MAX_REQUEST_LEN + APP_SPI_HANDSHAKE_BYTES)
+#define APP_SPI_RX_QUEUE_DEPTH     4u
+#define APP_SPI_STATUS_READY       0x00u
+#define APP_SPI_STATUS_BUSY        0xFFu
+#define APP_SPI_IDLE_FILL          0x00u
+
+#if (APP_SPI_HANDSHAKE_BITS % 8u) != 0
+#error "APP_SPI_HANDSHAKE_BITS must be a multiple of 8"
+#endif
+#if APP_SPI_HANDSHAKE_BYTES == 0
+#error "Handshake area must be at least one byte"
+#endif
+
+typedef struct {
+    uint8_t data[APP_SPI_MAX_REQUEST_LEN];
+    uint16_t len;
+} app_spi_frame_t;
+
 static router_t g_router;
 static router_handlers_t g_handlers;
 static response_fifo_t *g_resp_fifo;
 
-// SPI RX/TX buffers and state
-#ifndef APP_SPI_RX_BUF_SZ
-#define APP_SPI_RX_BUF_SZ 256u
-#endif
-static uint8_t g_spi_rx_buf[APP_SPI_RX_BUF_SZ];
-static uint16_t g_spi_rx_tail = 0;
+static uint8_t g_spi_rx_dma_buf[APP_SPI_DMA_BUF_LEN];
+static uint8_t g_spi_tx_dma_buf[APP_SPI_DMA_BUF_LEN];
+static volatile uint8_t g_spi_need_restart = 0;
+
+static app_spi_frame_t g_spi_rx_queue[APP_SPI_RX_QUEUE_DEPTH];
+static volatile uint8_t g_spi_rx_queue_head = 0;
+static volatile uint8_t g_spi_rx_queue_tail = 0;
+static volatile uint8_t g_spi_rx_queue_count = 0;
+static volatile uint8_t g_spi_rx_overflow = 0;
+
 static volatile int g_spi_tx_busy = 0;
 
 LOG_SVC_DEFINE(LOG_SVC_APP, "app");
 
-static void app_spi_drain_rx(void);
+static void app_spi_queue_reset(void);
+static void app_spi_prime_tx_buffer(uint8_t status);
+static uint8_t app_spi_compute_status(void);
+static void app_spi_restart_dma(uint8_t status);
+static void app_spi_try_restart_dma(void);
+static uint16_t app_spi_detect_frame_len(const uint8_t *buf);
+static int app_spi_queue_push_isr(const uint8_t *frame, uint16_t len);
+static int app_spi_queue_pop(app_spi_frame_t *out);
+static void app_spi_handle_txrx_complete(void);
 
 void app_init(void) {
-    // Init services (GPIO for LED etc.)
     led_service_init();
     log_service_init();
     test_spi_service_init();
-    // Boot log (visible on USART1 VCP terminal)
     LOGT_THIS(LOG_STATE_START, PROTO_OK, "start", "ready");
 
-    // Prepare router and response FIFO
     g_resp_fifo = resp_fifo_create();
     memset(&g_handlers, 0, sizeof g_handlers);
     services_register_handlers(&g_handlers);
     router_init(&g_router, g_resp_fifo, &g_handlers);
 
-    // Start SPI RX DMA in circular mode to feed router from callbacks
-    (void)HAL_SPI_Receive_DMA(&hspi1, g_spi_rx_buf, (uint16_t)APP_SPI_RX_BUF_SZ);
+    app_spi_queue_reset();
+    app_spi_prime_tx_buffer(APP_SPI_STATUS_READY);
+    if (HAL_SPI_TransmitReceive_DMA(&hspi1, g_spi_tx_dma_buf, g_spi_rx_dma_buf,
+                                    (uint16_t)APP_SPI_DMA_BUF_LEN) != HAL_OK) {
+        g_spi_need_restart = 1u;
+    }
 
-    // Enfileira um frame de teste: AB "hello" 54
     (void)test_spi_send_hello();
 }
 
 void app_poll(void) {
+    app_spi_try_restart_dma();
 
-    // Drain any bytes that arrived since the last iteration
-    app_spi_drain_rx();
+    app_spi_frame_t frame;
+    while (app_spi_queue_pop(&frame) == 0) {
+        router_feed_bytes(&g_router, frame.data, frame.len);
+    }
 
-    // If TX is idle, try to pop one response frame from FIFO and transmit
+    app_spi_try_restart_dma();
+
     if (!g_spi_tx_busy && g_resp_fifo) {
         uint8_t out[64];
         int n = resp_fifo_pop(g_resp_fifo, out, sizeof out);
         if (n > 0) {
-            // Use interrupt-driven TX to avoid DMA mode constraints
             if (HAL_SPI_Transmit_IT(&hspi1, out, (uint16_t)n) == HAL_OK) {
                 g_spi_tx_busy = 1;
             }
         }
     }
 
-    // Lowest priority: drain log output (non-blocking, only if USART idle)
-    //log_poll();
-}
-
-// Funções auxiliares invocadas por main.c a partir dos callbacks do HAL
-void app_on_spi_rx_half_complete(SPI_HandleTypeDef *h) {
-    if (h && h->Instance == SPI1) {
-        app_spi_drain_rx();
+    if (g_spi_rx_overflow) {
+        g_spi_rx_overflow = 0u;
+        LOGT_THIS(LOG_STATE_ERROR, PROTO_WARN, "spi_rx", "overflow");
     }
 }
 
-void app_on_spi_rx_complete(SPI_HandleTypeDef *h) {
+void app_on_spi_txrx_half_complete(SPI_HandleTypeDef *h) {
     if (h && h->Instance == SPI1) {
-        app_spi_drain_rx();
+        /* Nenhuma ação: handshake já foi enviado no primeiro byte */
+    }
+}
+
+void app_on_spi_txrx_complete(SPI_HandleTypeDef *h) {
+    if (h && h->Instance == SPI1) {
+        app_spi_handle_txrx_complete();
     }
 }
 
@@ -86,32 +123,117 @@ void app_on_spi_tx_complete(SPI_HandleTypeDef *h) {
 }
 
 int app_resp_push(const uint8_t *frame, uint32_t len) {
-    if (!g_resp_fifo || !frame || len == 0) return -1;
+    if (!g_resp_fifo || !frame || len == 0) {
+        return -1;
+    }
     return resp_fifo_push(g_resp_fifo, frame, len);
 }
 
-static void app_spi_drain_rx(void) {
-    if (!hspi1.hdmarx) {
+static void app_spi_queue_reset(void) {
+    __disable_irq();
+    g_spi_rx_queue_head = 0u;
+    g_spi_rx_queue_tail = 0u;
+    g_spi_rx_queue_count = 0u;
+    g_spi_rx_overflow = 0u;
+    __enable_irq();
+}
+
+static void app_spi_prime_tx_buffer(uint8_t status) {
+    g_spi_tx_dma_buf[0] = status;
+    if (APP_SPI_DMA_BUF_LEN > 1u) {
+        memset(&g_spi_tx_dma_buf[1], APP_SPI_IDLE_FILL, APP_SPI_DMA_BUF_LEN - 1u);
+    }
+}
+
+static uint8_t app_spi_compute_status(void) {
+    return (g_spi_rx_queue_count >= APP_SPI_RX_QUEUE_DEPTH)
+               ? APP_SPI_STATUS_BUSY
+               : APP_SPI_STATUS_READY;
+}
+
+static void app_spi_restart_dma(uint8_t status) {
+    if (HAL_SPI_GetState(&hspi1) != HAL_SPI_STATE_READY) {
+        g_spi_need_restart = 1u;
         return;
     }
 
-    uint16_t cur = (uint16_t)(APP_SPI_RX_BUF_SZ - __HAL_DMA_GET_COUNTER(hspi1.hdmarx));
-    uint16_t tail = g_spi_rx_tail;
-
-    if (cur == tail) {
-        return; // nothing new
-    }
-
-    g_spi_rx_tail = cur;
-
-    if (cur > tail) {
-        router_feed_bytes(&g_router, g_spi_rx_buf + tail, cur - tail);
+    app_spi_prime_tx_buffer(status);
+    if (HAL_SPI_TransmitReceive_DMA(&hspi1, g_spi_tx_dma_buf, g_spi_rx_dma_buf,
+                                    (uint16_t)APP_SPI_DMA_BUF_LEN) == HAL_OK) {
+        g_spi_need_restart = 0u;
     } else {
-        if (tail < APP_SPI_RX_BUF_SZ) {
-            router_feed_bytes(&g_router, g_spi_rx_buf + tail, APP_SPI_RX_BUF_SZ - tail);
-        }
-        if (cur > 0) {
-            router_feed_bytes(&g_router, g_spi_rx_buf, cur);
+        g_spi_need_restart = 1u;
+    }
+}
+
+static void app_spi_try_restart_dma(void) {
+    if (!g_spi_need_restart) {
+        return;
+    }
+    if (HAL_SPI_GetState(&hspi1) != HAL_SPI_STATE_READY) {
+        return;
+    }
+    app_spi_restart_dma(app_spi_compute_status());
+}
+
+static uint16_t app_spi_detect_frame_len(const uint8_t *buf) {
+    if (!buf || APP_SPI_DMA_BUF_LEN < 2u) {
+        return 0u;
+    }
+    if (buf[1] != REQ_HEADER) {
+        return 0u;
+    }
+    for (uint16_t i = 1u; i < APP_SPI_DMA_BUF_LEN; ++i) {
+        if (buf[i] == REQ_TAIL) {
+            if (i > APP_SPI_MAX_REQUEST_LEN) {
+                return 0u;
+            }
+            return i;
         }
     }
+    return 0u;
+}
+
+static int app_spi_queue_push_isr(const uint8_t *frame, uint16_t len) {
+    if (!frame || len == 0u || len > APP_SPI_MAX_REQUEST_LEN) {
+        return -1;
+    }
+    if (g_spi_rx_queue_count >= APP_SPI_RX_QUEUE_DEPTH) {
+        return -1;
+    }
+    app_spi_frame_t *slot = &g_spi_rx_queue[g_spi_rx_queue_head];
+    memcpy(slot->data, frame, len);
+    slot->len = len;
+    g_spi_rx_queue_head = (uint8_t)((g_spi_rx_queue_head + 1u) % APP_SPI_RX_QUEUE_DEPTH);
+    g_spi_rx_queue_count++;
+    return 0;
+}
+
+static int app_spi_queue_pop(app_spi_frame_t *out) {
+    int rc = -1;
+    __disable_irq();
+    if (g_spi_rx_queue_count > 0u) {
+        if (out) {
+            *out = g_spi_rx_queue[g_spi_rx_queue_tail];
+        }
+        g_spi_rx_queue_tail = (uint8_t)((g_spi_rx_queue_tail + 1u) % APP_SPI_RX_QUEUE_DEPTH);
+        g_spi_rx_queue_count--;
+        rc = 0;
+    }
+    __enable_irq();
+    return rc;
+}
+
+static void app_spi_handle_txrx_complete(void) {
+
+    uint16_t len = app_spi_detect_frame_len(g_spi_rx_dma_buf);
+    if (len > 0u) {
+        if (app_spi_queue_push_isr(&g_spi_rx_dma_buf[1], len) != 0) {
+            g_spi_rx_overflow = 1u;
+        }
+    } else {
+        g_spi_rx_overflow = 1u;
+    }
+
+    app_spi_restart_dma(app_spi_compute_status());
 }

--- a/CNC_Controller/App/Src/board_config.c
+++ b/CNC_Controller/App/Src/board_config.c
@@ -188,16 +188,16 @@ void board_config_apply_interrupt_priorities(void)
 
 void board_config_apply_spi_dma_profile(void)
 {
-    /* RX circular e prioritário: evita perda de comandos do mestre SPI */
+    /* RX em modo normal: cada quadro AA..55 + handshake ocupa um slot */
     configure_spi_dma(&hdma_spi1_rx,
                       DMA1_Channel2,
                       DMA_REQUEST_1,
                       DMA_PERIPH_TO_MEMORY,
-                      DMA_CIRCULAR,
+                      DMA_NORMAL,
                       DMA_PRIORITY_HIGH);
     __HAL_LINKDMA(&hspi1, hdmarx, hdma_spi1_rx);
 
-    /* TX em prioridade normal, disparado apenas quando há resposta no FIFO */
+    /* TX também em modo normal; buffers são preenchidos a cada transação */
     configure_spi_dma(&hdma_spi1_tx,
                       DMA1_Channel3,
                       DMA_REQUEST_1,

--- a/CNC_Controller/Core/Src/main.c
+++ b/CNC_Controller/Core/Src/main.c
@@ -176,14 +176,14 @@ void SystemClock_Config(void)
 }
 
 /* USER CODE BEGIN 4 */
-void HAL_SPI_RxHalfCpltCallback(SPI_HandleTypeDef *hspi)
+void HAL_SPI_TxRxHalfCpltCallback(SPI_HandleTypeDef *hspi)
 {
-  app_on_spi_rx_half_complete(hspi);
+  app_on_spi_txrx_half_complete(hspi);
 }
 
-void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi)
+void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi)
 {
-  app_on_spi_rx_complete(hspi);
+  app_on_spi_txrx_complete(hspi);
 }
 
 void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi)

--- a/CNC_Controller/Core/Src/spi.c
+++ b/CNC_Controller/Core/Src/spi.c
@@ -97,7 +97,7 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* spiHandle)
     hdma_spi1_rx.Init.MemInc = DMA_MINC_ENABLE;
     hdma_spi1_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
     hdma_spi1_rx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-    hdma_spi1_rx.Init.Mode = DMA_CIRCULAR;
+    hdma_spi1_rx.Init.Mode = DMA_NORMAL;
     hdma_spi1_rx.Init.Priority = DMA_PRIORITY_LOW;
     if (HAL_DMA_Init(&hdma_spi1_rx) != HAL_OK)
     {
@@ -114,7 +114,7 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* spiHandle)
     hdma_spi1_tx.Init.MemInc = DMA_MINC_ENABLE;
     hdma_spi1_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
     hdma_spi1_tx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-    hdma_spi1_tx.Init.Mode = DMA_CIRCULAR;
+    hdma_spi1_tx.Init.Mode = DMA_NORMAL;
     hdma_spi1_tx.Init.Priority = DMA_PRIORITY_LOW;
     if (HAL_DMA_Init(&hdma_spi1_tx) != HAL_OK)
     {


### PR DESCRIPTION
## Summary
- switch SPI handling to HAL_SPI_TransmitReceive_DMA with a ready/busy handshake byte and a queue to stage frames before routing
- update HAL callback wiring plus SPI1 DMA profiles to operate in normal Tx/Rx mode for the new flow

## Testing
- cmake -S . -B build (CNC_Controller/App/Tests)
- cmake --build build -j (CNC_Controller/App/Tests)
- ctest --test-dir build -V (CNC_Controller/App/Tests)


------
https://chatgpt.com/codex/tasks/task_e_68cd87c69e908326b121a0b3e194502d