### PR TITLE
Define handshake SPI alternativo e traduz comentários

### DIFF
--- a/CNC_Controller/App/Inc/Protocol/Requests/fpga_status_request.h
+++ b/CNC_Controller/App/Inc/Protocol/Requests/fpga_status_request.h
@@ -11,8 +11,8 @@ int fpga_status_req_decoder(const uint8_t *raw, uint32_t len,
 		fpga_status_req_t *out);
 int fpga_status_req_encoder(const fpga_status_req_t *in, uint8_t *raw,
 		uint32_t len);
-uint8_t fpga_status_req_calc_parity(const fpga_status_req_t *in); // N/A
-int fpga_status_req_check_parity(const uint8_t *raw, uint32_t len); // N/A
-int fpga_status_req_set_parity(uint8_t *raw, uint32_t len); // N/A
+uint8_t fpga_status_req_calc_parity(const fpga_status_req_t *in); // N/D
+int fpga_status_req_check_parity(const uint8_t *raw, uint32_t len); // N/D
+int fpga_status_req_set_parity(uint8_t *raw, uint32_t len); // N/D
 fpga_status_req_t fpga_status_req_make_default(void);
 

--- a/CNC_Controller/App/Inc/Protocol/Requests/move_end_request.h
+++ b/CNC_Controller/App/Inc/Protocol/Requests/move_end_request.h
@@ -9,8 +9,8 @@ typedef struct {
 
 int move_end_req_decoder(const uint8_t *raw, uint32_t len, move_end_req_t *out);
 int move_end_req_encoder(const move_end_req_t *in, uint8_t *raw, uint32_t len);
-uint8_t move_end_req_calc_parity(const move_end_req_t *in); // N/A
-int move_end_req_check_parity(const uint8_t *raw, uint32_t len); // N/A
-int move_end_req_set_parity(uint8_t *raw, uint32_t len); // N/A
+uint8_t move_end_req_calc_parity(const move_end_req_t *in); // N/D
+int move_end_req_check_parity(const uint8_t *raw, uint32_t len); // N/D
+int move_end_req_set_parity(uint8_t *raw, uint32_t len); // N/D
 move_end_req_t move_end_req_make_default(void);
 

--- a/CNC_Controller/App/Inc/Protocol/Requests/move_home_request.h
+++ b/CNC_Controller/App/Inc/Protocol/Requests/move_home_request.h
@@ -7,7 +7,7 @@ typedef struct {
 	uint8_t frameId;
 	uint8_t axisMask;
 	uint8_t dirMask;
-	uint16_t vhome; // big-endian on wire
+        uint16_t vhome; // big-endian na linha
 } move_home_req_t;
 
 int move_home_req_decoder(const uint8_t *raw, uint32_t len,

--- a/CNC_Controller/App/Inc/Protocol/Requests/move_probe_level_request.h
+++ b/CNC_Controller/App/Inc/Protocol/Requests/move_probe_level_request.h
@@ -6,7 +6,7 @@
 typedef struct {
 	uint8_t frameId;
 	uint8_t axisMask;
-	uint16_t vprobe; // big-endian on wire
+        uint16_t vprobe; // big-endian na linha
 } move_probe_level_req_t;
 
 int move_probe_level_req_decoder(const uint8_t *raw, uint32_t len,

--- a/CNC_Controller/App/Inc/Protocol/Requests/move_queue_add_request.h
+++ b/CNC_Controller/App/Inc/Protocol/Requests/move_queue_add_request.h
@@ -21,7 +21,7 @@ int move_queue_add_req_decoder(const uint8_t *raw, uint32_t len,
 		move_queue_add_req_t *out);
 int move_queue_add_req_encoder(const move_queue_add_req_t *in, uint8_t *raw,
 		uint32_t len);
-uint8_t move_queue_add_req_calc_parity(const move_queue_add_req_t *in); // returns bit in bit0
+uint8_t move_queue_add_req_calc_parity(const move_queue_add_req_t *in); // retorna o bit no bit0
 int move_queue_add_req_check_parity(const uint8_t *raw, uint32_t len);
 int move_queue_add_req_set_parity(uint8_t *raw, uint32_t len);
 move_queue_add_req_t move_queue_add_req_make_default(void);

--- a/CNC_Controller/App/Inc/Protocol/Requests/move_queue_status_request.h
+++ b/CNC_Controller/App/Inc/Protocol/Requests/move_queue_status_request.h
@@ -11,8 +11,8 @@ int move_queue_status_req_decoder(const uint8_t *raw, uint32_t len,
 		move_queue_status_req_t *out);
 int move_queue_status_req_encoder(const move_queue_status_req_t *in,
 		uint8_t *raw, uint32_t len);
-uint8_t move_queue_status_req_calc_parity(const move_queue_status_req_t *in); // N/A
-int move_queue_status_req_check_parity(const uint8_t *raw, uint32_t len); // N/A
-int move_queue_status_req_set_parity(uint8_t *raw, uint32_t len);         // N/A
+uint8_t move_queue_status_req_calc_parity(const move_queue_status_req_t *in); // N/D
+int move_queue_status_req_check_parity(const uint8_t *raw, uint32_t len); // N/D
+int move_queue_status_req_set_parity(uint8_t *raw, uint32_t len);         // N/D
 move_queue_status_req_t move_queue_status_req_make_default(void);
 

--- a/CNC_Controller/App/Inc/Protocol/Requests/start_move_request.h
+++ b/CNC_Controller/App/Inc/Protocol/Requests/start_move_request.h
@@ -11,8 +11,8 @@ int start_move_req_decoder(const uint8_t *raw, uint32_t len,
 		start_move_req_t *out);
 int start_move_req_encoder(const start_move_req_t *in, uint8_t *raw,
 		uint32_t len);
-uint8_t start_move_req_calc_parity(const start_move_req_t *in); // N/A
-int start_move_req_check_parity(const uint8_t *raw, uint32_t len); // N/A
-int start_move_req_set_parity(uint8_t *raw, uint32_t len); // N/A
+uint8_t start_move_req_calc_parity(const start_move_req_t *in); // N/D
+int start_move_req_check_parity(const uint8_t *raw, uint32_t len); // N/D
+int start_move_req_set_parity(uint8_t *raw, uint32_t len); // N/D
 start_move_req_t start_move_req_make_default(void);
 

--- a/CNC_Controller/App/Inc/Protocol/Responses/move_end_response.h
+++ b/CNC_Controller/App/Inc/Protocol/Responses/move_end_response.h
@@ -10,8 +10,8 @@ typedef struct {
 int move_end_resp_decoder(const uint8_t *raw, uint32_t len,
 		move_end_resp_t *out);
 int move_end_resp_encoder(const move_end_resp_t *in, uint8_t *raw, uint32_t len);
-uint8_t move_end_resp_calc_parity(const move_end_resp_t *in); // N/A
-int move_end_resp_check_parity(const uint8_t *raw, uint32_t len); // N/A
-int move_end_resp_set_parity(uint8_t *raw, uint32_t len); // N/A
+uint8_t move_end_resp_calc_parity(const move_end_resp_t *in); // N/D
+int move_end_resp_check_parity(const uint8_t *raw, uint32_t len); // N/D
+int move_end_resp_set_parity(uint8_t *raw, uint32_t len); // N/D
 move_end_resp_t move_end_resp_make_default(void);
 

--- a/CNC_Controller/App/Inc/Protocol/Responses/move_queue_add_ack_response.h
+++ b/CNC_Controller/App/Inc/Protocol/Responses/move_queue_add_ack_response.h
@@ -12,7 +12,7 @@ int move_queue_add_ack_resp_decoder(const uint8_t *raw, uint32_t len,
 		move_queue_add_ack_resp_t *out);
 int move_queue_add_ack_resp_encoder(const move_queue_add_ack_resp_t *in,
 		uint8_t *raw, uint32_t len);
-uint8_t move_queue_add_ack_resp_calc_parity(const move_queue_add_ack_resp_t *in); // bit reduce of bytes 1..3
+uint8_t move_queue_add_ack_resp_calc_parity(const move_queue_add_ack_resp_t *in); // redução aos bits dos bytes 1..3
 int move_queue_add_ack_resp_check_parity(const uint8_t *raw, uint32_t len);
 int move_queue_add_ack_resp_set_parity(uint8_t *raw, uint32_t len);
 move_queue_add_ack_resp_t move_queue_add_ack_resp_make_default(void);

--- a/CNC_Controller/App/Inc/Protocol/Responses/move_queue_status_response.h
+++ b/CNC_Controller/App/Inc/Protocol/Responses/move_queue_status_response.h
@@ -14,7 +14,7 @@ int move_queue_status_resp_decoder(const uint8_t *raw, uint32_t len,
 		move_queue_status_resp_t *out);
 int move_queue_status_resp_encoder(const move_queue_status_resp_t *in,
 		uint8_t *raw, uint32_t len);
-uint8_t move_queue_status_resp_calc_parity(const move_queue_status_resp_t *in); // bit reduce of bytes 1..9
+uint8_t move_queue_status_resp_calc_parity(const move_queue_status_resp_t *in); // redução aos bits dos bytes 1..9
 int move_queue_status_resp_check_parity(const uint8_t *raw, uint32_t len);
 int move_queue_status_resp_set_parity(uint8_t *raw, uint32_t len);
 move_queue_status_resp_t move_queue_status_resp_make_default(void);

--- a/CNC_Controller/App/Inc/Protocol/Responses/start_move_response.h
+++ b/CNC_Controller/App/Inc/Protocol/Responses/start_move_response.h
@@ -11,8 +11,8 @@ int start_move_resp_decoder(const uint8_t *raw, uint32_t len,
 		start_move_resp_t *out);
 int start_move_resp_encoder(const start_move_resp_t *in, uint8_t *raw,
 		uint32_t len);
-uint8_t start_move_resp_calc_parity(const start_move_resp_t *in); // N/A
-int start_move_resp_check_parity(const uint8_t *raw, uint32_t len); // N/A
-int start_move_resp_set_parity(uint8_t *raw, uint32_t len); // N/A
+uint8_t start_move_resp_calc_parity(const start_move_resp_t *in); // N/D
+int start_move_resp_check_parity(const uint8_t *raw, uint32_t len); // N/D
+int start_move_resp_set_parity(uint8_t *raw, uint32_t len); // N/D
 start_move_resp_t start_move_resp_make_default(void);
 

--- a/CNC_Controller/App/Inc/Protocol/frame_defs.h
+++ b/CNC_Controller/App/Inc/Protocol/frame_defs.h
@@ -1,13 +1,13 @@
-// Frame definitions aligned with README (IDs, headers, tails)
+// Definições de frame alinhadas com o README (IDs, headers, tails)
 #pragma once
 #include <stdint.h>
 
-// Framing bytes
+// Bytes de enquadramento
 enum {
 	REQ_HEADER = 0xAA, REQ_TAIL = 0x55, RESP_HEADER = 0xAB, RESP_TAIL = 0x54,
 };
 
-// Request message types (STM32 receives)
+// Tipos de mensagens de requisição (STM32 recebe)
 typedef enum {
 	REQ_MOVE_QUEUE_ADD = 0x01,
 	REQ_MOVE_QUEUE_STATUS = 0x02,
@@ -19,7 +19,7 @@ typedef enum {
 	REQ_FPGA_STATUS = 0x20,
 } req_msg_type_t;
 
-// Response message types (STM32 sends)
+// Tipos de mensagens de resposta (STM32 envia)
 typedef enum {
 	RESP_MOVE_QUEUE_ADD_ACK = 0x01,
 	RESP_MOVE_QUEUE_STATUS = 0x02,
@@ -33,10 +33,10 @@ typedef enum {
 } resp_msg_type_t;
 
 // =====================
-// Generic helper toolkit
+// Conjunto genérico de auxiliares
 // =====================
 
-// XOR over bytes (full-byte parity)
+// XOR sobre bytes (paridade byte a byte)
 static inline uint8_t xor_reduce_bytes(const uint8_t *p, uint32_t n) {
 	uint8_t x = 0;
 	for (uint32_t i = 0; i < n; ++i)
@@ -44,7 +44,7 @@ static inline uint8_t xor_reduce_bytes(const uint8_t *p, uint32_t n) {
 	return x;
 }
 
-// XOR bit-reduction over bytes (returns single parity bit in bit0)
+// Redução de XOR bit a bit (retorna um único bit de paridade no bit0)
 static inline uint8_t xor_bit_reduce_bytes(const uint8_t *p, uint32_t n) {
 	uint8_t x = 0;
 	for (uint32_t i = 0; i < n; ++i)
@@ -55,7 +55,7 @@ static inline uint8_t xor_bit_reduce_bytes(const uint8_t *p, uint32_t n) {
 	return (uint8_t) (x & 0x1);
 }
 
-// Check/set byte parity over a range: parity stored at raw[parity_index]
+// Verifica/ajusta a paridade por byte em um intervalo: valor em raw[parity_index]
 static inline int check_parity_byte(const uint8_t *raw, uint32_t start,
 		uint32_t count, uint32_t parity_index) {
 	if (!raw)
@@ -70,7 +70,7 @@ static inline int set_parity_byte(uint8_t *raw, uint32_t start, uint32_t count,
 	return 0;
 }
 
-// Check/set bit-reduced parity over a range: LSB of raw[parity_index]
+// Verifica/ajusta a paridade reduzida a um bit: LSB de raw[parity_index]
 static inline int check_parity_bit(const uint8_t *raw, uint32_t start,
 		uint32_t count, uint32_t parity_index) {
 	if (!raw)
@@ -87,13 +87,13 @@ static inline int set_parity_bit(uint8_t *raw, uint32_t start, uint32_t count,
 	return 0;
 }
 
-// Generic header/tail validation
+// Validação genérica de header/tail
 static inline int has_header_tail(const uint8_t *raw, uint32_t len,
 		uint8_t header, uint8_t tail) {
 	return raw && len >= 2 && raw[0] == header && raw[len - 1] == tail;
 }
 
-// Big-endian reads/writes (wire format)
+// Leituras/escritas big-endian (formato no fio)
 static inline uint16_t be16_read(const uint8_t *p) {
 	return (uint16_t) ((((uint16_t) p[0]) << 8) | p[1]);
 }
@@ -113,27 +113,27 @@ static inline void be32_write(uint8_t *p, uint32_t v) {
 }
 
 // =====================
-// Standard return codes
+// Códigos de retorno padronizados
 // =====================
-// Use across encoders/decoders/validators for uniformity
+// Usados por encoders/decoders/validadores para manter uniformidade
 typedef enum {
-	PROTO_OK = 0,   // Success
-	PROTO_WARN = 1,   // Non-fatal condition (optional use)
+        PROTO_OK = 0,   // Sucesso
+        PROTO_WARN = 1,   // Condição não fatal (uso opcional)
 
-	PROTO_ERR_ARG = -1,  // Invalid argument(s) or length
-	PROTO_ERR_FRAME = -2,  // Framing/type mismatch
-	PROTO_ERR_ALLOC = -3,  // Allocation failure
-	PROTO_ERR_RANGE = -4,  // Range/overflow/insufficient buffer
-	PROTO_ERR_PARITY = -5,  // Parity/checksum mismatch
+        PROTO_ERR_ARG = -1,  // Argumento(s) ou tamanho inválido(s)
+        PROTO_ERR_FRAME = -2,  // Cabeçalho/tipo incompatível
+        PROTO_ERR_ALLOC = -3,  // Falha de alocação
+        PROTO_ERR_RANGE = -4,  // Faixa/overflow/buffer insuficiente
+        PROTO_ERR_PARITY = -5,  // Erro de paridade/checksum
 } proto_result_t;
 
-// Helpers to test result categories
+// Auxiliares para testar categorias de resultado
 #define PROTO_SUCCEEDED(x)   ((x) >= 0)
 #define PROTO_FAILED(x)      ((x) < 0)
 #define PROTO_IS_WARN(x)     ((x) > 0)
 
 // =====================
-// Frame helpers (init/tail)
+// Auxiliares de frame (init/tail)
 // =====================
 static inline void req_init(uint8_t *raw, req_msg_type_t type) {
 	raw[0] = REQ_HEADER;
@@ -151,9 +151,9 @@ static inline void resp_set_tail(uint8_t *raw, uint32_t tail_index) {
 }
 
 // =====================
-// Frame validators
+// Validadores de frame
 // =====================
-// Ensure buffer has min length, proper header/tail, and expected type
+// Garante comprimento mínimo, header/tail corretos e tipo esperado
 static inline int frame_expect_req(const uint8_t *raw, uint32_t len,
 		req_msg_type_t type, uint32_t min_len) {
 	if (!raw || len < min_len)
@@ -174,9 +174,9 @@ static inline int frame_expect_resp(const uint8_t *raw, uint32_t len,
 }
 
 // =====================
-// Parity wrappers (1..N range)
+// Wrappers de paridade (intervalo 1..N)
 // =====================
-// These assume parity covers bytes from index 1 (type) through last_index inclusive
+// Assume que a paridade cobre os bytes do índice 1 (tipo) até last_index inclusive
 static inline int parity_set_byte_1N(uint8_t *raw, uint32_t last_index,
 		uint32_t parity_index) {
 	return set_parity_byte(raw, 1, last_index, parity_index);

--- a/CNC_Controller/App/Inc/Protocol/router.h
+++ b/CNC_Controller/App/Inc/Protocol/router.h
@@ -1,4 +1,4 @@
-// SPI frame router (AA..55 -> services, AB..54 <- responses)
+// Roteador de frames SPI (AA..55 -> serviços, AB..54 <- respostas)
 #pragma once
 #include <stdint.h>
 #include "frame_defs.h"
@@ -7,17 +7,17 @@
 extern "C" {
 #endif
 
-// Simple response FIFO API (opaque to callers)
+// API simples do FIFO de respostas (opaca para quem chama)
 typedef struct response_fifo_s response_fifo_t;
 
-// Router state
+// Estado do roteador
 typedef struct {
-	uint8_t acc[64];   // small accumulator buffer
+        uint8_t acc[64];   // buffer acumulador pequeno
 	uint8_t idx;
 	response_fifo_t *resp;
 } router_t;
 
-// Callback types for dispatch
+// Tipos de callback para despacho
 typedef void (*req_handler_fn)(router_t *r, const uint8_t *frame, uint32_t len);
 
 typedef struct {
@@ -33,15 +33,15 @@ typedef struct {
 
 void router_init(router_t *r, response_fifo_t *resp_fifo,
 		const router_handlers_t *h);
-// Feed bytes from SPI RX DMA callbacks (half/full complete)
+// Alimenta bytes vindos dos callbacks de SPI RX DMA (meia/transferência completa)
 void router_feed_bytes(router_t *r, const uint8_t *data, uint32_t len);
 
-// Response FIFO minimal API (producer side)
+// API mínima do FIFO de respostas (lado produtor)
 response_fifo_t* resp_fifo_create(void);
 void resp_fifo_destroy(response_fifo_t *q);
-// Push a fully formed response frame (AB..54)
+// Empilha um frame de resposta completo (AB..54)
 int resp_fifo_push(response_fifo_t *q, const uint8_t *frame, uint32_t len);
-// Pop for transmission (caller owns buffer lifetime)
+// Retira para transmissão (quem chama controla o buffer)
 int resp_fifo_pop(response_fifo_t *q, uint8_t *out, uint32_t max_len);
 int resp_fifo_count(const response_fifo_t *q);
 

--- a/CNC_Controller/App/Inc/Services/Home/home_service.h
+++ b/CNC_Controller/App/Inc/Services/Home/home_service.h
@@ -1,4 +1,4 @@
-// Home service (FSM por eixo)
+// Serviço de homing (FSM por eixo)
 #pragma once
 #include <stdint.h>
 

--- a/CNC_Controller/App/Inc/Services/Log/log_service.h
+++ b/CNC_Controller/App/Inc/Services/Log/log_service.h
@@ -1,15 +1,15 @@
-// Non-interruptive SWO logging service
+// Serviço de logging via SWO sem interrupções
 #pragma once
 
 #include <stdint.h>
 #include <stddef.h>
 
-// Compile-time gate: set to 0 to strip logging at build time
+// Chave de compilação: ajuste para 0 para remover o logging na construção
 #ifndef LOG_ENABLE
 #define LOG_ENABLE 1
 #endif
 
-// Canonical service and state IDs for concise mode (always available)
+// IDs canônicos de serviço e estado para o modo conciso (sempre disponíveis)
 typedef enum {
     LOG_SVC_APP = 0,
     LOG_SVC_LED = 1,
@@ -23,33 +23,33 @@ typedef enum {
     LOG_STATE_START = 0,
     LOG_STATE_RECEIVED = 1,
     LOG_STATE_APPLIED = 2,
-    // Safety-specific
+    // Eventos específicos de segurança
     LOG_STATE_ESTOP_ASSERT = 10,
     LOG_STATE_ESTOP_RELEASE = 11,
-    // Generic error bucket (use with PROTO_ERR_*)
+    // Balde genérico de erro (usar com PROTO_ERR_*)
     LOG_STATE_ERROR = 100,
 } log_state_id_t;
 
 #if LOG_ENABLE
 
-// Initialize logging (sets stdout unbuffered)
+// Inicializa o logging (coloca stdout sem buffer)
 void log_service_init(void);
 
-// Enqueue concise event: service/state IDs and numeric status (ok/warn/err)
+// Empilha evento conciso: IDs de serviço/estado e status numérico (ok/warn/err)
 void log_event_ids(uint8_t service_id, uint8_t state_id, int32_t status);
 
-// Enqueue verbose event: names and textual status
+// Empilha evento verboso: nomes e status textual
 void log_event_names(const char* service_name, const char* state_name, const char* status_text);
 
-// Drain pending log bytes opportunistically (non-blocking)
+// Drena bytes pendentes do log de forma oportunista (não bloqueante)
 void log_poll(void);
 
-// Convenience: single entry point (formats status with printf-style fmt and args).
+// Conveniência: ponto único que formata status com printf e argumentos variáveis.
 void log_event_auto(log_service_id_t service_id, log_state_id_t state_id, int32_t status,
                     const char* service_name, const char* state_name,
                     const char* fmt, ...);
 
-// Minimal macros to reduce call-site noise
+// Macros mínimas para reduzir ruído nos pontos de chamada
 #define LOG_SVC_DEFINE(id, name) \
     enum { LOG_SVC_THIS = (id) }; \
     static const char* const LOG_SVC_THIS_NAME = (name)
@@ -60,7 +60,7 @@ void log_event_auto(log_service_id_t service_id, log_state_id_t state_id, int32_
 #define LOGA_THIS(state_id, status, state_name, ...) \
     do { LOGA(LOG_SVC_THIS,(state_id),(status),LOG_SVC_THIS_NAME,(state_name), __VA_ARGS__); } while(0)
 
-// Text-only helpers (no % placeholders):
+// Auxiliares apenas com texto (sem marcadores %):
 #define LOGT(svc_id, state_id, status, svc_name, state_name, text) \
     LOGA((svc_id),(state_id),(status),(svc_name),(state_name), "%s", (text))
 #define LOGT_THIS(state_id, status, state_name, text) \
@@ -72,7 +72,7 @@ static inline void log_service_init(void) {}
 static inline void log_event_ids(uint8_t s, uint8_t t, int32_t st) { (void)s; (void)t; (void)st; }
 static inline void log_event_names(const char* a, const char* b, const char* c) { (void)a; (void)b; (void)c; }
 static inline void log_poll(void) {}
-// When disabled, make macros no-ops so call-sites remain clean
+// Quando desativado, deixa as macros como no-ops para manter os call-sites limpos
 #define LOG_SVC_DEFINE(id, name)
 #define LOGA(svc_id, state_id, status, svc_name, state_name, ...)
 #define LOGA_THIS(state_id, status, state_name, ...)

--- a/CNC_Controller/App/Inc/Services/Motion/motion_service.h
+++ b/CNC_Controller/App/Inc/Services/Motion/motion_service.h
@@ -1,4 +1,4 @@
-// Motion service (FSM simplificado) — interface
+// Serviço de movimento (FSM simplificado) — interface
 #pragma once
 #include <stdint.h>
 

--- a/CNC_Controller/App/Inc/Services/Probe/probe_service.h
+++ b/CNC_Controller/App/Inc/Services/Probe/probe_service.h
@@ -1,4 +1,4 @@
-// Probe level service (FSM simplificado)
+// Serviço de nivelamento por probe (FSM simplificado)
 #pragma once
 #include <stdint.h>
 

--- a/CNC_Controller/App/Inc/Services/Safety/safety_service.h
+++ b/CNC_Controller/App/Inc/Services/Safety/safety_service.h
@@ -1,4 +1,4 @@
-// Safety service (E-STOP/FAULT)
+// Serviço de segurança (E-STOP/FAULT)
 #pragma once
 #include <stdint.h>
 

--- a/CNC_Controller/App/Inc/Services/service_adapters.h
+++ b/CNC_Controller/App/Inc/Services/service_adapters.h
@@ -1,4 +1,4 @@
-// Adapters to bind services to router handlers
+// Adaptadores que vinculam os serviços aos handlers do roteador
 #pragma once
 #include "../Protocol/router.h"
 

--- a/CNC_Controller/App/Inc/app.h
+++ b/CNC_Controller/App/Inc/app.h
@@ -1,19 +1,37 @@
-// App bootstrap: wires SPI DMA callbacks to protocol router and services
+// Inicialização da aplicação: integra SPI DMA, roteador de protocolo e serviços
 #pragma once
 
-// Forward declaration to avoid including HAL headers here
+// Declaração antecipada para evitar incluir os headers do HAL aqui
 typedef struct __SPI_HandleTypeDef SPI_HandleTypeDef;
 
-// Initialize app subsystems (router, services, SPI DMA)
+/**
+ * @brief Inicializa os subsistemas da aplicação (roteador, serviços e SPI DMA).
+ */
 void app_init(void);
 
-// Poll for pending responses to transmit over SPI
+/**
+ * @brief Processa rotinas periódicas, transmitindo respostas pendentes via SPI.
+ */
 void app_poll(void);
 
-// Allow services to push a raw response frame (AB..54) into TX FIFO
+/**
+ * @brief Permite que os serviços empilhem um frame de resposta bruto (AB..54).
+ *
+ * @param frame Ponteiro para o frame completo.
+ * @param len   Tamanho do frame em bytes.
+ * @return 0 em caso de sucesso, código de erro negativo em falha.
+ */
 int app_resp_push(const uint8_t *frame, uint32_t len);
 
-// Hooks invoked from HAL callbacks (defined in main.c)
-void app_on_spi_rx_half_complete(SPI_HandleTypeDef *h);
-void app_on_spi_rx_complete(SPI_HandleTypeDef *h);
+/**
+ * @brief Hook para o callback de meia transferência do SPI DMA.
+ */
+void app_on_spi_txrx_half_complete(SPI_HandleTypeDef *h);
+/**
+ * @brief Hook para o callback de transferência completa do SPI DMA.
+ */
+void app_on_spi_txrx_complete(SPI_HandleTypeDef *h);
+/**
+ * @brief Hook para o callback de transmissão concluída do SPI (modo IT).
+ */
 void app_on_spi_tx_complete(SPI_HandleTypeDef *h);

--- a/CNC_Controller/App/Src/Protocol/router.c
+++ b/CNC_Controller/App/Src/Protocol/router.c
@@ -1,4 +1,4 @@
-// Minimal, self-contained router stub (not linked by default in CubeIDE)
+// Roteador mínimo e autocontido (não é vinculado por padrão no CubeIDE)
 #include <string.h>
 #include <stdlib.h>
 #include "Protocol/router.h"

--- a/CNC_Controller/App/Src/Services/Log/log_service.c
+++ b/CNC_Controller/App/Src/Services/Log/log_service.c
@@ -1,4 +1,4 @@
-// Simplified log service: route everything to printf (USART1 via _write)
+// Serviço de log simplificado: envia tudo para printf (USART1 via _write)
 #include "Services/Log/log_service.h"
 #if LOG_ENABLE
 
@@ -8,12 +8,12 @@
 #include "usart.h"
 
 void log_service_init(void){
-    // Ensure stdout is unbuffered so printf flushes immediately to UART.
+    // Garante stdout sem buffer para que o printf descarregue imediatamente na UART.
     setvbuf(stdout, NULL, _IONBF, 0);
 }
 
 void log_poll(void){
-    // No-op: transmission is synchronous via _write/HAL_UART_Transmit.
+    // No-op: a transmissão é síncrona via _write/HAL_UART_Transmit.
 }
 
 void log_event_ids(uint8_t service_id, uint8_t state_id, int32_t status){
@@ -27,7 +27,7 @@ void log_event_names(const char* service_name, const char* state_name, const cha
     printf("LOG:service=%s,state=%s,status=%s\r\n", service_name, state_name, status_text);
 }
 
-// Keep _write exactly as-is: used by printf to send to USART1.
+// Mantém _write exatamente igual: utilizado pelo printf para enviar à USART1.
 int _write(int fd, char *ptr, int len) {
     HAL_StatusTypeDef hstatus;
 

--- a/CNC_Controller/App/Src/Services/service_adapters.c
+++ b/CNC_Controller/App/Src/Services/service_adapters.c
@@ -4,7 +4,7 @@
 #include "Services/Probe/probe_service.h"
 #include "Services/Led/led_service.h"
 
-// Static adapter functions matching router callbacks
+// Funções estáticas de adaptação compatíveis com os callbacks do roteador
 static void h_move_queue_add(router_t *r, const uint8_t *f, uint32_t l) {
 	(void) r;
 	motion_on_move_queue_add(f, l);

--- a/CNC_Controller/App/Src/app.c
+++ b/CNC_Controller/App/Src/app.c
@@ -1,81 +1,123 @@
 #include <string.h>
 #include "spi.h"
 #include "app.h"
+#include "Protocol/frame_defs.h"
 #include "Protocol/router.h"
 #include "Services/service_adapters.h"
 #include "Services/Led/led_service.h"
 #include "Services/Log/log_service.h"
 #include "Services/Test/test_spi_service.h"
 
-// Router + response queue
+#define APP_SPI_MAX_REQUEST_LEN    42u
+#define APP_SPI_HANDSHAKE_BITS     8u
+#define APP_SPI_HANDSHAKE_BYTES    (APP_SPI_HANDSHAKE_BITS / 8u)
+#define APP_SPI_DMA_BUF_LEN        (APP_SPI_MAX_REQUEST_LEN + APP_SPI_HANDSHAKE_BYTES)
+#define APP_SPI_RX_QUEUE_DEPTH     4u
+#define APP_SPI_STATUS_READY       0x5Au
+#define APP_SPI_STATUS_BUSY        0xA5u
+/* Estados de handshake usam padrões alternados para evitar colisão com 0x00/0xFF. */
+#define APP_SPI_IDLE_FILL          0x00u
+
+#if (APP_SPI_HANDSHAKE_BITS % 8u) != 0
+#error "APP_SPI_HANDSHAKE_BITS must be a multiple of 8"
+#endif
+#if APP_SPI_HANDSHAKE_BYTES == 0
+#error "Handshake area must be at least one byte"
+#endif
+
+typedef struct {
+    uint8_t data[APP_SPI_MAX_REQUEST_LEN];
+    uint16_t len;
+} app_spi_frame_t;
+
 static router_t g_router;
 static router_handlers_t g_handlers;
 static response_fifo_t *g_resp_fifo;
 
-// SPI RX/TX buffers and state
-#ifndef APP_SPI_RX_BUF_SZ
-#define APP_SPI_RX_BUF_SZ 256u
-#endif
-static uint8_t g_spi_rx_buf[APP_SPI_RX_BUF_SZ];
-static uint16_t g_spi_rx_tail = 0;
+static uint8_t g_spi_rx_dma_buf[APP_SPI_DMA_BUF_LEN];
+static uint8_t g_spi_tx_dma_buf[APP_SPI_DMA_BUF_LEN];
+static volatile uint8_t g_spi_need_restart = 0;
+static volatile uint8_t g_spi_next_status = APP_SPI_STATUS_READY;
+
+static app_spi_frame_t g_spi_rx_queue[APP_SPI_RX_QUEUE_DEPTH];
+static volatile uint8_t g_spi_rx_queue_head = 0;
+static volatile uint8_t g_spi_rx_queue_tail = 0;
+static volatile uint8_t g_spi_rx_queue_count = 0;
+static volatile uint8_t g_spi_rx_overflow = 0;
+
 static volatile int g_spi_tx_busy = 0;
 
 LOG_SVC_DEFINE(LOG_SVC_APP, "app");
 
-static void app_spi_drain_rx(void);
+static void app_spi_queue_reset(void);
+static void app_spi_prime_tx_buffer(uint8_t status);
+static uint8_t app_spi_compute_status(void);
+static void app_spi_restart_dma(uint8_t status);
+static void app_spi_try_restart_dma(void);
+static int app_spi_locate_frame(const uint8_t *buf, uint16_t *offset, uint16_t *len);
+static int app_spi_queue_push_isr(const uint8_t *frame, uint16_t len);
+static int app_spi_queue_pop(app_spi_frame_t *out);
+static void app_spi_handle_txrx_complete(void);
 
 void app_init(void) {
-    // Init services (GPIO for LED etc.)
     led_service_init();
     log_service_init();
     test_spi_service_init();
-    // Boot log (visible on USART1 VCP terminal)
     LOGT_THIS(LOG_STATE_START, PROTO_OK, "start", "ready");
 
-    // Prepare router and response FIFO
     g_resp_fifo = resp_fifo_create();
     memset(&g_handlers, 0, sizeof g_handlers);
     services_register_handlers(&g_handlers);
     router_init(&g_router, g_resp_fifo, &g_handlers);
 
-    // Start SPI RX DMA in circular mode to feed router from callbacks
-    (void)HAL_SPI_Receive_DMA(&hspi1, g_spi_rx_buf, (uint16_t)APP_SPI_RX_BUF_SZ);
+    app_spi_queue_reset();
+    g_spi_next_status = APP_SPI_STATUS_READY;
+    app_spi_prime_tx_buffer(g_spi_next_status);
+    if (HAL_SPI_TransmitReceive_DMA(&hspi1, g_spi_tx_dma_buf, g_spi_rx_dma_buf,
+                                    (uint16_t)APP_SPI_DMA_BUF_LEN) != HAL_OK) {
+        g_spi_need_restart = 1u;
+    }
 
-    // Enfileira um frame de teste: AB "hello" 54
     (void)test_spi_send_hello();
 }
 
 void app_poll(void) {
+    app_spi_try_restart_dma();
 
-    // Drain any bytes that arrived since the last iteration
-    app_spi_drain_rx();
+    app_spi_frame_t frame;
+    while (app_spi_queue_pop(&frame) == 0) {
+        router_feed_bytes(&g_router, frame.data, frame.len);
+    }
 
-    // If TX is idle, try to pop one response frame from FIFO and transmit
+    app_spi_try_restart_dma();
+
     if (!g_spi_tx_busy && g_resp_fifo) {
         uint8_t out[64];
         int n = resp_fifo_pop(g_resp_fifo, out, sizeof out);
         if (n > 0) {
-            // Use interrupt-driven TX to avoid DMA mode constraints
             if (HAL_SPI_Transmit_IT(&hspi1, out, (uint16_t)n) == HAL_OK) {
                 g_spi_tx_busy = 1;
             }
         }
     }
 
-    // Lowest priority: drain log output (non-blocking, only if USART idle)
-    //log_poll();
-}
-
-// Funções auxiliares invocadas por main.c a partir dos callbacks do HAL
-void app_on_spi_rx_half_complete(SPI_HandleTypeDef *h) {
-    if (h && h->Instance == SPI1) {
-        app_spi_drain_rx();
+    if (g_spi_rx_overflow) {
+        g_spi_rx_overflow = 0u;
+        LOGT_THIS(LOG_STATE_ERROR, PROTO_WARN, "spi_rx", "overflow");
     }
 }
 
-void app_on_spi_rx_complete(SPI_HandleTypeDef *h) {
+void app_on_spi_txrx_half_complete(SPI_HandleTypeDef *h) {
     if (h && h->Instance == SPI1) {
-        app_spi_drain_rx();
+        /* Reserva o handshake para sinalizar BUSY até concluir o tratamento atual */
+        g_spi_next_status = APP_SPI_STATUS_BUSY;
+        g_spi_tx_dma_buf[0] = APP_SPI_STATUS_BUSY;
+    }
+}
+
+void app_on_spi_txrx_complete(SPI_HandleTypeDef *h) {
+    if (h && h->Instance == SPI1) {
+        app_spi_handle_txrx_complete();
     }
 }
 
@@ -86,32 +128,139 @@ void app_on_spi_tx_complete(SPI_HandleTypeDef *h) {
 }
 
 int app_resp_push(const uint8_t *frame, uint32_t len) {
-    if (!g_resp_fifo || !frame || len == 0) return -1;
+    if (!g_resp_fifo || !frame || len == 0) {
+        return -1;
+    }
     return resp_fifo_push(g_resp_fifo, frame, len);
 }
 
-static void app_spi_drain_rx(void) {
-    if (!hspi1.hdmarx) {
+static void app_spi_queue_reset(void) {
+    __disable_irq();
+    g_spi_rx_queue_head = 0u;
+    g_spi_rx_queue_tail = 0u;
+    g_spi_rx_queue_count = 0u;
+    g_spi_rx_overflow = 0u;
+    __enable_irq();
+}
+
+static void app_spi_prime_tx_buffer(uint8_t status) {
+    g_spi_tx_dma_buf[0] = status;
+    if (APP_SPI_DMA_BUF_LEN > 1u) {
+        memset(&g_spi_tx_dma_buf[1], APP_SPI_IDLE_FILL, APP_SPI_DMA_BUF_LEN - 1u);
+    }
+}
+
+static uint8_t app_spi_compute_status(void) {
+    return (g_spi_rx_queue_count >= APP_SPI_RX_QUEUE_DEPTH)
+               ? APP_SPI_STATUS_BUSY
+               : APP_SPI_STATUS_READY;
+}
+
+static void app_spi_restart_dma(uint8_t status) {
+    if (HAL_SPI_GetState(&hspi1) != HAL_SPI_STATE_READY) {
+        g_spi_need_restart = 1u;
         return;
     }
 
-    uint16_t cur = (uint16_t)(APP_SPI_RX_BUF_SZ - __HAL_DMA_GET_COUNTER(hspi1.hdmarx));
-    uint16_t tail = g_spi_rx_tail;
-
-    if (cur == tail) {
-        return; // nothing new
-    }
-
-    g_spi_rx_tail = cur;
-
-    if (cur > tail) {
-        router_feed_bytes(&g_router, g_spi_rx_buf + tail, cur - tail);
+    g_spi_next_status = status;
+    app_spi_prime_tx_buffer(status);
+    if (HAL_SPI_TransmitReceive_DMA(&hspi1, g_spi_tx_dma_buf, g_spi_rx_dma_buf,
+                                    (uint16_t)APP_SPI_DMA_BUF_LEN) == HAL_OK) {
+        g_spi_need_restart = 0u;
     } else {
-        if (tail < APP_SPI_RX_BUF_SZ) {
-            router_feed_bytes(&g_router, g_spi_rx_buf + tail, APP_SPI_RX_BUF_SZ - tail);
-        }
-        if (cur > 0) {
-            router_feed_bytes(&g_router, g_spi_rx_buf, cur);
+        g_spi_need_restart = 1u;
+    }
+}
+
+static void app_spi_try_restart_dma(void) {
+    if (!g_spi_need_restart) {
+        return;
+    }
+    if (HAL_SPI_GetState(&hspi1) != HAL_SPI_STATE_READY) {
+        return;
+    }
+    app_spi_restart_dma(g_spi_next_status);
+}
+
+static int app_spi_locate_frame(const uint8_t *buf, uint16_t *offset, uint16_t *len) {
+    if (!buf || !offset || !len || APP_SPI_DMA_BUF_LEN < 2u) {
+        return -1;
+    }
+
+    uint16_t start = 1u;
+    while (start < APP_SPI_DMA_BUF_LEN && buf[start] == APP_SPI_IDLE_FILL) {
+        ++start;
+    }
+
+    if (start >= APP_SPI_DMA_BUF_LEN || buf[start] != REQ_HEADER) {
+        return -1;
+    }
+
+    for (uint16_t i = (uint16_t)(start + 1u); i < APP_SPI_DMA_BUF_LEN; ++i) {
+        if (buf[i] == REQ_TAIL) {
+            uint16_t frame_len = (uint16_t)(i - start + 1u);
+            if (frame_len > APP_SPI_MAX_REQUEST_LEN) {
+                return -1;
+            }
+            *offset = start;
+            *len = frame_len;
+            return 0;
         }
     }
+
+    return -1;
+}
+
+static int app_spi_queue_push_isr(const uint8_t *frame, uint16_t len) {
+    if (!frame || len == 0u || len > APP_SPI_MAX_REQUEST_LEN) {
+        return -1;
+    }
+    if (g_spi_rx_queue_count >= APP_SPI_RX_QUEUE_DEPTH) {
+        return -1;
+    }
+    app_spi_frame_t *slot = &g_spi_rx_queue[g_spi_rx_queue_head];
+    memcpy(slot->data, frame, len);
+    slot->len = len;
+    g_spi_rx_queue_head = (uint8_t)((g_spi_rx_queue_head + 1u) % APP_SPI_RX_QUEUE_DEPTH);
+    g_spi_rx_queue_count++;
+    return 0;
+}
+
+static int app_spi_queue_pop(app_spi_frame_t *out) {
+    int rc = -1;
+    __disable_irq();
+    if (g_spi_rx_queue_count > 0u) {
+        if (out) {
+            *out = g_spi_rx_queue[g_spi_rx_queue_tail];
+        }
+        g_spi_rx_queue_tail = (uint8_t)((g_spi_rx_queue_tail + 1u) % APP_SPI_RX_QUEUE_DEPTH);
+        g_spi_rx_queue_count--;
+        rc = 0;
+    }
+    __enable_irq();
+    return rc;
+}
+
+static void app_spi_handle_txrx_complete(void) {
+    uint16_t offset = 0u;
+    uint16_t len = 0u;
+    uint8_t armazenado = 0u;
+
+    if (app_spi_locate_frame(g_spi_rx_dma_buf, &offset, &len) == 0) {
+        if (app_spi_queue_push_isr(&g_spi_rx_dma_buf[offset], len) == 0) {
+            armazenado = 1u;
+        } else {
+            g_spi_rx_overflow = 1u;
+        }
+    } else {
+        g_spi_rx_overflow = 1u;
+    }
+
+    if (armazenado) {
+        g_spi_next_status = app_spi_compute_status();
+    } else {
+        g_spi_next_status = APP_SPI_STATUS_BUSY;
+    }
+
+    app_spi_restart_dma(g_spi_next_status);
 }

--- a/CNC_Controller/App/Src/board_config.c
+++ b/CNC_Controller/App/Src/board_config.c
@@ -188,16 +188,16 @@ void board_config_apply_interrupt_priorities(void)
 
 void board_config_apply_spi_dma_profile(void)
 {
-    /* RX circular e prioritário: evita perda de comandos do mestre SPI */
+    /* RX em modo normal: cada quadro AA..55 + handshake ocupa um slot */
     configure_spi_dma(&hdma_spi1_rx,
                       DMA1_Channel2,
                       DMA_REQUEST_1,
                       DMA_PERIPH_TO_MEMORY,
-                      DMA_CIRCULAR,
+                      DMA_NORMAL,
                       DMA_PRIORITY_HIGH);
     __HAL_LINKDMA(&hspi1, hdmarx, hdma_spi1_rx);
 
-    /* TX em prioridade normal, disparado apenas quando há resposta no FIFO */
+    /* TX também em modo normal; buffers são preenchidos a cada transação */
     configure_spi_dma(&hdma_spi1_tx,
                       DMA1_Channel3,
                       DMA_REQUEST_1,

--- a/CNC_Controller/App/Tests/test_protocol.c
+++ b/CNC_Controller/App/Tests/test_protocol.c
@@ -78,14 +78,14 @@ static void test_response_fifo_basic(void){
     assert(memcmp(out, frame, 6) == 0);
     assert(resp_fifo_count(q) == 0);
 
-    // Range error path
+    // Caminho de erro de faixa
     rc = resp_fifo_push(q, frame, sizeof frame);
     assert(rc == 0);
     uint8_t small[4];
     n = resp_fifo_pop(q, small, sizeof small);
     assert(n < 0); // PROTO_ERR_RANGE
 
-    // cleanup
+    // limpeza
     resp_fifo_destroy(q);
 }
 

--- a/CNC_Controller/Core/Src/main.c
+++ b/CNC_Controller/Core/Src/main.c
@@ -176,14 +176,14 @@ void SystemClock_Config(void)
 }
 
 /* USER CODE BEGIN 4 */
-void HAL_SPI_RxHalfCpltCallback(SPI_HandleTypeDef *hspi)
+void HAL_SPI_TxRxHalfCpltCallback(SPI_HandleTypeDef *hspi)
 {
-  app_on_spi_rx_half_complete(hspi);
+  app_on_spi_txrx_half_complete(hspi);
 }
 
-void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi)
+void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi)
 {
-  app_on_spi_rx_complete(hspi);
+  app_on_spi_txrx_complete(hspi);
 }
 
 void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi)

--- a/CNC_Controller/Core/Src/spi.c
+++ b/CNC_Controller/Core/Src/spi.c
@@ -97,7 +97,7 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* spiHandle)
     hdma_spi1_rx.Init.MemInc = DMA_MINC_ENABLE;
     hdma_spi1_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
     hdma_spi1_rx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-    hdma_spi1_rx.Init.Mode = DMA_CIRCULAR;
+    hdma_spi1_rx.Init.Mode = DMA_NORMAL;
     hdma_spi1_rx.Init.Priority = DMA_PRIORITY_LOW;
     if (HAL_DMA_Init(&hdma_spi1_rx) != HAL_OK)
     {
@@ -114,7 +114,7 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* spiHandle)
     hdma_spi1_tx.Init.MemInc = DMA_MINC_ENABLE;
     hdma_spi1_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
     hdma_spi1_tx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-    hdma_spi1_tx.Init.Mode = DMA_CIRCULAR;
+    hdma_spi1_tx.Init.Mode = DMA_NORMAL;
     hdma_spi1_tx.Init.Priority = DMA_PRIORITY_LOW;
     if (HAL_DMA_Init(&hdma_spi1_tx) != HAL_OK)
     {


### PR DESCRIPTION
## Summary
- ajusta os estados READY/BUSY do handshake SPI para 0x5A/0xA5 no firmware e no cliente Python
- documenta os hooks da aplicação e traduz os comentários dos módulos em App para português
- atualiza comentários de protocolo e serviços para manter a consistência do idioma

## Testing
- cmake -S . -B build (CNC_Controller/App/Tests)
- cmake --build build -j (CNC_Controller/App/Tests)
- ctest --test-dir build -V (CNC_Controller/App/Tests)


------
https://chatgpt.com/codex/tasks/task_e_68cd87c69e908326b121a0b3e194502d