### PR TITLE
Fix SPI client relative imports for direct execution

### DIFF
--- a/raspberry_spi/cnc_client.py
+++ b/raspberry_spi/cnc_client.py
@@ -1,18 +1,36 @@
 """Cliente SPI que conversa com o firmware CNC no STM32."""
 
+import sys
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-from .cnc_protocol import (
-    RESP_HEADER,
-    RESP_TAIL,
-    SPI_DMA_FRAME_LEN,
-    SPI_DMA_HANDSHAKE_BUSY,
-    SPI_DMA_HANDSHAKE_READY,
-    SPI_DMA_MAX_PAYLOAD,
-    bits_str,
-)
-from .cnc_responses import CNCResponseDecoder
+MODULE_DIR = Path(__file__).resolve().parent
+
+if __package__:
+    from .cnc_protocol import (
+        RESP_HEADER,
+        RESP_TAIL,
+        SPI_DMA_FRAME_LEN,
+        SPI_DMA_HANDSHAKE_BUSY,
+        SPI_DMA_HANDSHAKE_READY,
+        SPI_DMA_MAX_PAYLOAD,
+        bits_str,
+    )
+    from .cnc_responses import CNCResponseDecoder
+else:
+    if str(MODULE_DIR) not in sys.path:
+        sys.path.insert(0, str(MODULE_DIR))
+    from cnc_protocol import (  # type: ignore
+        RESP_HEADER,
+        RESP_TAIL,
+        SPI_DMA_FRAME_LEN,
+        SPI_DMA_HANDSHAKE_BUSY,
+        SPI_DMA_HANDSHAKE_READY,
+        SPI_DMA_MAX_PAYLOAD,
+        bits_str,
+    )
+    from cnc_responses import CNCResponseDecoder  # type: ignore
 
 try:  # pragma: no cover - dependência externa
     import spidev  # type: ignore

--- a/raspberry_spi/cnc_commands.py
+++ b/raspberry_spi/cnc_commands.py
@@ -1,21 +1,42 @@
 """Camada de aplicação com comandos disponíveis via CLI."""
 
 import argparse
+import sys
+from pathlib import Path
 from typing import Any, Dict, List
 
-from .cnc_client import CNCClient
-from .cnc_protocol import (
-    REQ_LED_CTRL,
-    REQ_MOVE_END,
-    REQ_MOVE_HOME,
-    REQ_MOVE_PROBE_LEVEL,
-    REQ_MOVE_QUEUE_ADD,
-    REQ_MOVE_QUEUE_STATUS,
-    REQ_START_MOVE,
-    bits_str,
-)
-from .cnc_requests import CNCRequestBuilder
-from .cnc_responses import CNCResponseDecoder
+MODULE_DIR = Path(__file__).resolve().parent
+
+if __package__:
+    from .cnc_client import CNCClient
+    from .cnc_protocol import (
+        REQ_LED_CTRL,
+        REQ_MOVE_END,
+        REQ_MOVE_HOME,
+        REQ_MOVE_PROBE_LEVEL,
+        REQ_MOVE_QUEUE_ADD,
+        REQ_MOVE_QUEUE_STATUS,
+        REQ_START_MOVE,
+        bits_str,
+    )
+    from .cnc_requests import CNCRequestBuilder
+    from .cnc_responses import CNCResponseDecoder
+else:
+    if str(MODULE_DIR) not in sys.path:
+        sys.path.insert(0, str(MODULE_DIR))
+    from cnc_client import CNCClient  # type: ignore
+    from cnc_protocol import (  # type: ignore
+        REQ_LED_CTRL,
+        REQ_MOVE_END,
+        REQ_MOVE_HOME,
+        REQ_MOVE_PROBE_LEVEL,
+        REQ_MOVE_QUEUE_ADD,
+        REQ_MOVE_QUEUE_STATUS,
+        REQ_START_MOVE,
+        bits_str,
+    )
+    from cnc_requests import CNCRequestBuilder  # type: ignore
+    from cnc_responses import CNCResponseDecoder  # type: ignore
 
 
 def print_boot_frame_info(frame: List[int], stats: Dict[str, Any]) -> None:

--- a/raspberry_spi/cnc_requests.py
+++ b/raspberry_spi/cnc_requests.py
@@ -1,24 +1,49 @@
 """Montagem de requisições para o protocolo CNC SPI."""
 
+import sys
+from pathlib import Path
 from typing import List
 
-from .cnc_protocol import (
-    REQ_FPGA_STATUS,
-    REQ_HEADER,
-    REQ_LED_CTRL,
-    REQ_MOVE_END,
-    REQ_MOVE_HOME,
-    REQ_MOVE_PROBE_LEVEL,
-    REQ_MOVE_QUEUE_ADD,
-    REQ_MOVE_QUEUE_STATUS,
-    REQ_START_MOVE,
-    REQ_TAIL,
-    be16_bytes,
-    be32_bytes,
-    pad_request,
-    parity_set_bit_1N,
-    parity_set_byte_1N,
-)
+MODULE_DIR = Path(__file__).resolve().parent
+
+if __package__:
+    from .cnc_protocol import (
+        REQ_FPGA_STATUS,
+        REQ_HEADER,
+        REQ_LED_CTRL,
+        REQ_MOVE_END,
+        REQ_MOVE_HOME,
+        REQ_MOVE_PROBE_LEVEL,
+        REQ_MOVE_QUEUE_ADD,
+        REQ_MOVE_QUEUE_STATUS,
+        REQ_START_MOVE,
+        REQ_TAIL,
+        be16_bytes,
+        be32_bytes,
+        pad_request,
+        parity_set_bit_1N,
+        parity_set_byte_1N,
+    )
+else:
+    if str(MODULE_DIR) not in sys.path:
+        sys.path.insert(0, str(MODULE_DIR))
+    from cnc_protocol import (  # type: ignore
+        REQ_FPGA_STATUS,
+        REQ_HEADER,
+        REQ_LED_CTRL,
+        REQ_MOVE_END,
+        REQ_MOVE_HOME,
+        REQ_MOVE_PROBE_LEVEL,
+        REQ_MOVE_QUEUE_ADD,
+        REQ_MOVE_QUEUE_STATUS,
+        REQ_START_MOVE,
+        REQ_TAIL,
+        be16_bytes,
+        be32_bytes,
+        pad_request,
+        parity_set_bit_1N,
+        parity_set_byte_1N,
+    )
 
 
 class CNCRequestBuilder:

--- a/raspberry_spi/cnc_responses.py
+++ b/raspberry_spi/cnc_responses.py
@@ -1,29 +1,58 @@
 """Decodificadores de respostas do protocolo CNC SPI."""
 
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Callable, Dict, List
 
-from .cnc_protocol import (
-    REQ_LED_CTRL,
-    REQ_MOVE_END,
-    REQ_MOVE_HOME,
-    REQ_MOVE_PROBE_LEVEL,
-    REQ_MOVE_QUEUE_ADD,
-    REQ_MOVE_QUEUE_STATUS,
-    REQ_START_MOVE,
-    RESP_HEADER,
-    RESP_HOME_STATUS,
-    RESP_LED_CTRL,
-    RESP_MOVE_END,
-    RESP_MOVE_HOME,
-    RESP_MOVE_PROBE_LEVEL,
-    RESP_MOVE_QUEUE_ADD_ACK,
-    RESP_MOVE_QUEUE_STATUS,
-    RESP_START_MOVE,
-    RESP_TAIL,
-    parity_check_bit_1N,
-    parity_check_byte_1N,
-)
+MODULE_DIR = Path(__file__).resolve().parent
+
+if __package__:
+    from .cnc_protocol import (
+        REQ_LED_CTRL,
+        REQ_MOVE_END,
+        REQ_MOVE_HOME,
+        REQ_MOVE_PROBE_LEVEL,
+        REQ_MOVE_QUEUE_ADD,
+        REQ_MOVE_QUEUE_STATUS,
+        REQ_START_MOVE,
+        RESP_HEADER,
+        RESP_HOME_STATUS,
+        RESP_LED_CTRL,
+        RESP_MOVE_END,
+        RESP_MOVE_HOME,
+        RESP_MOVE_PROBE_LEVEL,
+        RESP_MOVE_QUEUE_ADD_ACK,
+        RESP_MOVE_QUEUE_STATUS,
+        RESP_START_MOVE,
+        RESP_TAIL,
+        parity_check_bit_1N,
+        parity_check_byte_1N,
+    )
+else:
+    if str(MODULE_DIR) not in sys.path:
+        sys.path.insert(0, str(MODULE_DIR))
+    from cnc_protocol import (  # type: ignore
+        REQ_LED_CTRL,
+        REQ_MOVE_END,
+        REQ_MOVE_HOME,
+        REQ_MOVE_PROBE_LEVEL,
+        REQ_MOVE_QUEUE_ADD,
+        REQ_MOVE_QUEUE_STATUS,
+        REQ_START_MOVE,
+        RESP_HEADER,
+        RESP_HOME_STATUS,
+        RESP_LED_CTRL,
+        RESP_MOVE_END,
+        RESP_MOVE_HOME,
+        RESP_MOVE_PROBE_LEVEL,
+        RESP_MOVE_QUEUE_ADD_ACK,
+        RESP_MOVE_QUEUE_STATUS,
+        RESP_START_MOVE,
+        RESP_TAIL,
+        parity_check_bit_1N,
+        parity_check_byte_1N,
+    )
 
 
 @dataclass(frozen=True)

--- a/raspberry_spi/cnc_spi_client.py
+++ b/raspberry_spi/cnc_spi_client.py
@@ -4,12 +4,18 @@
 """Cliente SPI para comunicação com o firmware CNC no STM32."""
 
 import argparse
+import sys
+from pathlib import Path
 from typing import List, Optional
+
+MODULE_DIR = Path(__file__).resolve().parent
 
 if __package__:
     from .cnc_client import CNCClient
     from .cnc_commands import CNCCommandExecutor
 else:  # execução direta do script a partir do diretório raspberry_spi
+    if str(MODULE_DIR) not in sys.path:
+        sys.path.insert(0, str(MODULE_DIR))
     from cnc_client import CNCClient
     from cnc_commands import CNCCommandExecutor
 


### PR DESCRIPTION
## Summary
- ensure the Raspberry Pi SPI client modules gracefully handle being imported both as a package and as standalone scripts
- add sys.path bootstrapping so cnc_spi_client.py and its helpers work when executed directly from the raspberry_spi folder

## Testing
- `python3 raspberry_spi/cnc_spi_client.py queue-status --frame-id 2` *(fails: RuntimeError: spidev não disponível. Instale `python3-spidev` no Raspberry.)*

------
https://chatgpt.com/codex/tasks/task_e_68cddbd51b3c8326a99a72ed3646029e