### PR TITLE
Fix LED service pin conflict with SPI1

### DIFF
--- a/CNC_Controller/App/Inc/Services/Led/led_service.h
+++ b/CNC_Controller/App/Inc/Services/Led/led_service.h
@@ -3,14 +3,14 @@
 #include <stdint.h>
 
 // Mapeamento de GPIO para o LED discreto presente no controlador.
-// Os padrões seguem a placa B-L475E-IOT01A, onde o LED1 (verde) está no PA5.
-// Sobrescreva via definições de compilação ao direcionar para outra placa
-// ou ligação.
+// Os padrões seguem a placa B-L475E-IOT01A, onde o LED verde discreto (LD2)
+// está conectado ao PB14. Sobrescreva via definições de compilação ao
+// direcionar para outra placa ou ligação.
 #ifndef LED1_GPIO_PORT
-#define LED1_GPIO_PORT GPIOA
+#define LED1_GPIO_PORT GPIOB
 #endif
 #ifndef LED1_GPIO_PIN
-#define LED1_GPIO_PIN  GPIO_PIN_5
+#define LED1_GPIO_PIN  GPIO_PIN_14
 #endif
 
 // Nível lógico que acende o LED.

--- a/CNC_Controller/App/README.md
+++ b/CNC_Controller/App/README.md
@@ -26,7 +26,7 @@ Servico de Log (USART1 VCP)
 - Habilitacao: `LOG_ENABLE` (compile-time, padrao=1) e `log_set_enabled()` (runtime). Quando desabilitado em build-time, as funcoes viram no-ops e nao afetam a compilacao.
 - Padrao: inicia em modo VERBOSE (`LOG_DEFAULT_MODE=LOG_MODE_VERBOSE`). Pode alterar via compile-time ou `log_set_mode()`.
 
-Servico de LED — LED1 discreto
+Servico de LED — LED discreto
 - Arquivos: `Services/Led/led_service.h`, `Services/Led/led_service.c`.
 - O servico controla o LED verde discreto (LED1) presente na placa.
 - Mapeamento de pinos via macros (ajuste conforme sua placa/wiring):
@@ -36,8 +36,12 @@ Servico de LED — LED1 discreto
 - O pisca é mantido por interrupção de hardware (TIM15) com período de 1 ms; não há necessidade de *polling* na *main loop*.
 
 Pinos padrao (B-L475E-IOT01A)
-- `LED1_GPIO_PORT=GPIOA`, `LED1_GPIO_PIN=GPIO_PIN_5`  (LD1/verde)
+- `LED1_GPIO_PORT=GPIOB`, `LED1_GPIO_PIN=GPIO_PIN_14`  (LD2/verde)
 - `LED_ACTIVE_HIGH=1`
+
+> **Atenção:** O mapeamento anterior (PA5) conflita com o sinal SCK do SPI1.
+> Caso utilize uma fiação diferente, ajuste as macros via opções de
+> compilação para evitar sobrescrever os pinos do barramento SPI.
 
 Protocolo LED_CTRL (LED1)
 - Tipo: `REQ_LED_CTRL = 0x07`


### PR DESCRIPTION
## Summary
- retarget the default LED GPIO mapping to PB14 so the LED service no longer reconfigures the SPI1 SCK pin
- update the LED service documentation to reflect the new default pinout and warn about SPI pin conflicts

## Testing
- not run (STM32 firmware project)


------
https://chatgpt.com/codex/tasks/task_e_68cedf9083e08326bfadfc53fd0169f6