### PR TITLE
Relax SPI frame header search

### DIFF
--- a/CNC_Controller/App/Src/app.c
+++ b/CNC_Controller/App/Src/app.c
@@ -191,12 +191,12 @@ static int app_spi_locate_frame(const uint8_t *buf, uint16_t *offset, uint16_t *
         return -1;
     }
 
-    uint16_t start = 1u;
-    while (start < APP_SPI_DMA_BUF_LEN && buf[start] == APP_SPI_IDLE_FILL) {
+    uint16_t start = APP_SPI_HANDSHAKE_BYTES;
+    while (start < APP_SPI_DMA_BUF_LEN && buf[start] != REQ_HEADER) {
         ++start;
     }
 
-    if (start >= APP_SPI_DMA_BUF_LEN || buf[start] != REQ_HEADER) {
+    if (start >= APP_SPI_DMA_BUF_LEN) {
         return -1;
     }
 


### PR DESCRIPTION
## Summary
- update the DMA frame parser to look for the request header after the handshake bytes instead of assuming padding bytes are zero
- prevent request drops when the Raspberry Pi sends a different filler value ahead of the header

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d02c75b7b48326ac4ee6a60a7e0f6e