### PR TITLE
Ajusta firmware STM32 para handshake SPI byte a byte

### DIFF
--- a/CNC_Controller/App/Src/board_config.c
+++ b/CNC_Controller/App/Src/board_config.c
@@ -188,7 +188,7 @@ void board_config_apply_interrupt_priorities(void)
 
 void board_config_apply_spi_dma_profile(void)
 {
-    /* RX em modo normal: cada quadro AA..55 + handshake ocupa um slot */
+    /* RX em modo normal: cada quadro AA..55 + handshakes byte a byte ocupa um slot */
     configure_spi_dma(&hdma_spi1_rx,
                       DMA1_Channel2,
                       DMA_REQUEST_1,

--- a/raspberry_spi/cnc_protocol.py
+++ b/raspberry_spi/cnc_protocol.py
@@ -33,10 +33,22 @@ RESP_TEST_HELLO = 0x68
 
 # SPI DMA framing (STM32 handshake + payload)
 SPI_DMA_MAX_PAYLOAD = 42
-SPI_DMA_HANDSHAKE_BYTES = 1
-SPI_DMA_FRAME_LEN = SPI_DMA_HANDSHAKE_BYTES + SPI_DMA_MAX_PAYLOAD
+SPI_DMA_HANDSHAKE_BYTES = 0
+SPI_DMA_FRAME_LEN = SPI_DMA_MAX_PAYLOAD
 SPI_DMA_HANDSHAKE_READY = 0xA5
 SPI_DMA_HANDSHAKE_BUSY = 0x5A
+
+# Handshake interpretation helpers (per-byte status echo from STM32)
+SPI_DMA_HANDSHAKE_STATUS_LABELS = {
+    SPI_DMA_HANDSHAKE_READY: "ok",
+    SPI_DMA_HANDSHAKE_BUSY: "fila cheia/busy",
+}
+
+
+def handshake_status_label(code: int) -> str:
+    """Retorna uma descrição curta para o status de handshake informado."""
+
+    return SPI_DMA_HANDSHAKE_STATUS_LABELS.get(code & 0xFF, "desconhecido")
 
 
 def xor_reduce_bytes(bs: List[int]) -> int:
@@ -132,6 +144,8 @@ __all__ = [
     "SPI_DMA_FRAME_LEN",
     "SPI_DMA_HANDSHAKE_READY",
     "SPI_DMA_HANDSHAKE_BUSY",
+    "SPI_DMA_HANDSHAKE_STATUS_LABELS",
+    "handshake_status_label",
     "xor_reduce_bytes",
     "xor_bit_reduce_bytes",
     "be16_bytes",

--- a/raspberry_spi/test_handshake_validation.py
+++ b/raspberry_spi/test_handshake_validation.py
@@ -1,0 +1,65 @@
+import sys
+import unittest
+from pathlib import Path
+
+MODULE_DIR = Path(__file__).resolve().parent
+
+if __package__:
+    from .cnc_client import _build_spi_dma_frame, _validate_handshake_frame
+    from .cnc_protocol import (
+        REQ_HEADER,
+        REQ_LED_CTRL,
+        REQ_TAIL,
+        SPI_DMA_FRAME_LEN,
+        SPI_DMA_HANDSHAKE_BUSY,
+        SPI_DMA_HANDSHAKE_READY,
+    )
+else:
+    if str(MODULE_DIR) not in sys.path:
+        sys.path.insert(0, str(MODULE_DIR))
+    from cnc_client import _build_spi_dma_frame, _validate_handshake_frame  # type: ignore
+    from cnc_protocol import (  # type: ignore
+        REQ_HEADER,
+        REQ_LED_CTRL,
+        REQ_TAIL,
+        SPI_DMA_FRAME_LEN,
+        SPI_DMA_HANDSHAKE_BUSY,
+        SPI_DMA_HANDSHAKE_READY,
+    )
+
+
+class HandshakeValidationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        payload = [REQ_HEADER, REQ_LED_CTRL, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, REQ_TAIL]
+        self.payload = payload
+        self.frame = _build_spi_dma_frame(payload)
+
+    def test_accepts_ready_handshake_for_entire_frame(self) -> None:
+        handshake = [SPI_DMA_HANDSHAKE_READY] * SPI_DMA_FRAME_LEN
+        _validate_handshake_frame(self.frame, handshake, len(self.payload))
+
+    def test_busy_handshake_raises_buffer_error_with_payload_context(self) -> None:
+        handshake = [SPI_DMA_HANDSHAKE_READY] * SPI_DMA_FRAME_LEN
+        handshake[-1] = SPI_DMA_HANDSHAKE_BUSY
+
+        with self.assertRaises(BufferError) as ctx:
+            _validate_handshake_frame(self.frame, handshake, len(self.payload))
+
+        msg = str(ctx.exception)
+        self.assertIn("payload[", msg)
+        self.assertIn("0x5A", msg)
+
+    def test_unknown_handshake_raises_runtime_error_on_padding(self) -> None:
+        handshake = [SPI_DMA_HANDSHAKE_READY] * SPI_DMA_FRAME_LEN
+        handshake[0] = 0xE1
+
+        with self.assertRaises(RuntimeError) as ctx:
+            _validate_handshake_frame(self.frame, handshake, len(self.payload))
+
+        msg = str(ctx.exception)
+        self.assertIn("preenchimento[0]", msg)
+        self.assertIn("0xE1", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove a área dedicada de handshake do buffer DMA e passa a preencher todos os 42 bytes com o status atual
- garante que a busca pelo frame recebido considera o início do buffer, compatibilizando com o novo empacotamento
- atualiza a documentação do perfil de DMA para refletir o handshake byte a byte

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d03d86ab948326af359f213bb57214