### PR TITLE
Handle SPI handshake no-communication status

### DIFF
--- a/raspberry_spi/cnc_client.py
+++ b/raspberry_spi/cnc_client.py
@@ -17,6 +17,7 @@ if __package__:
         SPI_DMA_FRAME_LEN,
         SPI_DMA_HANDSHAKE_BUSY,
         SPI_DMA_HANDSHAKE_BYTES,
+        SPI_DMA_HANDSHAKE_NO_COMM,
         SPI_DMA_HANDSHAKE_READY,
         SPI_DMA_MAX_PAYLOAD,
         handshake_status_label,
@@ -35,6 +36,7 @@ else:
         SPI_DMA_FRAME_LEN,
         SPI_DMA_HANDSHAKE_BUSY,
         SPI_DMA_HANDSHAKE_BYTES,
+        SPI_DMA_HANDSHAKE_NO_COMM,
         SPI_DMA_HANDSHAKE_READY,
         SPI_DMA_MAX_PAYLOAD,
         handshake_status_label,
@@ -93,6 +95,11 @@ def _validate_handshake_frame(
         )
         if status == SPI_DMA_HANDSHAKE_BUSY:
             raise BufferError(base_msg + " Aguarde e tente novamente.")
+        if status == SPI_DMA_HANDSHAKE_NO_COMM:
+            raise ConnectionError(
+                base_msg
+                + " Comunicação SPI não ocorreu (verifique alimentação, conexões e configuração)."
+            )
         raise RuntimeError(base_msg)
 
 

--- a/raspberry_spi/cnc_protocol.py
+++ b/raspberry_spi/cnc_protocol.py
@@ -37,11 +37,13 @@ SPI_DMA_HANDSHAKE_BYTES = 0
 SPI_DMA_FRAME_LEN = SPI_DMA_MAX_PAYLOAD
 SPI_DMA_HANDSHAKE_READY = 0xA5
 SPI_DMA_HANDSHAKE_BUSY = 0x5A
+SPI_DMA_HANDSHAKE_NO_COMM = 0x00
 
 # Handshake interpretation helpers (per-byte status echo from STM32)
 SPI_DMA_HANDSHAKE_STATUS_LABELS = {
     SPI_DMA_HANDSHAKE_READY: "ok",
     SPI_DMA_HANDSHAKE_BUSY: "fila cheia/busy",
+    SPI_DMA_HANDSHAKE_NO_COMM: "sem comunicação",
 }
 
 
@@ -144,6 +146,7 @@ __all__ = [
     "SPI_DMA_FRAME_LEN",
     "SPI_DMA_HANDSHAKE_READY",
     "SPI_DMA_HANDSHAKE_BUSY",
+    "SPI_DMA_HANDSHAKE_NO_COMM",
     "SPI_DMA_HANDSHAKE_STATUS_LABELS",
     "handshake_status_label",
     "xor_reduce_bytes",

--- a/raspberry_spi/test_handshake_validation.py
+++ b/raspberry_spi/test_handshake_validation.py
@@ -12,6 +12,7 @@ if __package__:
         REQ_TAIL,
         SPI_DMA_FRAME_LEN,
         SPI_DMA_HANDSHAKE_BUSY,
+        SPI_DMA_HANDSHAKE_NO_COMM,
         SPI_DMA_HANDSHAKE_READY,
     )
 else:
@@ -24,6 +25,7 @@ else:
         REQ_TAIL,
         SPI_DMA_FRAME_LEN,
         SPI_DMA_HANDSHAKE_BUSY,
+        SPI_DMA_HANDSHAKE_NO_COMM,
         SPI_DMA_HANDSHAKE_READY,
     )
 
@@ -59,6 +61,16 @@ class HandshakeValidationTests(unittest.TestCase):
         msg = str(ctx.exception)
         self.assertIn("preenchimento[0]", msg)
         self.assertIn("0xE1", msg)
+
+    def test_zero_handshake_raises_connection_error(self) -> None:
+        handshake = [SPI_DMA_HANDSHAKE_NO_COMM] * SPI_DMA_FRAME_LEN
+
+        with self.assertRaises(ConnectionError) as ctx:
+            _validate_handshake_frame(self.frame, handshake, len(self.payload))
+
+        msg = str(ctx.exception)
+        self.assertIn("0x00", msg)
+        self.assertIn("Comunicação SPI não ocorreu", msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add explicit constant for the 0x00 SPI handshake value and label it as missing communication
- surface a ConnectionError when the handshake reports no communication instead of ready/busy
- cover the new status handling with unit tests for the SPI handshake validator

## Testing
- python3 -m unittest discover -s raspberry_spi

------
https://chatgpt.com/codex/tasks/task_e_68d07115ba208326ac98be1bd704d11f