### PR TITLE
Handle SPI handshake no-communication status

### DIFF
--- a/raspberry_spi/cnc_protocol.py
+++ b/raspberry_spi/cnc_protocol.py
@@ -37,11 +37,13 @@ SPI_DMA_HANDSHAKE_BYTES = 0
 SPI_DMA_FRAME_LEN = SPI_DMA_MAX_PAYLOAD
 SPI_DMA_HANDSHAKE_READY = 0xA5
 SPI_DMA_HANDSHAKE_BUSY = 0x5A
+SPI_DMA_HANDSHAKE_NO_COMM = 0x00
 
 # Handshake interpretation helpers (per-byte status echo from STM32)
 SPI_DMA_HANDSHAKE_STATUS_LABELS = {
     SPI_DMA_HANDSHAKE_READY: "ok",
     SPI_DMA_HANDSHAKE_BUSY: "fila cheia/busy",
+    SPI_DMA_HANDSHAKE_NO_COMM: "sem comunicação",
 }
 
 
@@ -144,6 +146,7 @@ __all__ = [
     "SPI_DMA_FRAME_LEN",
     "SPI_DMA_HANDSHAKE_READY",
     "SPI_DMA_HANDSHAKE_BUSY",
+    "SPI_DMA_HANDSHAKE_NO_COMM",
     "SPI_DMA_HANDSHAKE_STATUS_LABELS",
     "handshake_status_label",
     "xor_reduce_bytes",

--- a/raspberry_spi/test_cnc_client_exchange.py
+++ b/raspberry_spi/test_cnc_client_exchange.py
@@ -1,0 +1,131 @@
+import sys
+import types
+import unittest
+from pathlib import Path
+
+MODULE_DIR = Path(__file__).resolve().parent
+
+if __package__:
+    from .cnc_client import CNCClient, _build_spi_dma_frame
+    from .cnc_protocol import (
+        REQ_LED_CTRL,
+        RESP_HEADER,
+        RESP_LED_CTRL,
+        RESP_TAIL,
+        SPI_DMA_FRAME_LEN,
+        SPI_DMA_HANDSHAKE_READY,
+    )
+    from .cnc_requests import CNCRequestBuilder
+else:
+    if str(MODULE_DIR) not in sys.path:
+        sys.path.insert(0, str(MODULE_DIR))
+    from cnc_client import CNCClient, _build_spi_dma_frame  # type: ignore
+    from cnc_protocol import (  # type: ignore
+        REQ_LED_CTRL,
+        RESP_HEADER,
+        RESP_LED_CTRL,
+        RESP_TAIL,
+        SPI_DMA_FRAME_LEN,
+        SPI_DMA_HANDSHAKE_READY,
+    )
+    from cnc_requests import CNCRequestBuilder  # type: ignore
+
+
+class _DummySpi:
+    def __init__(self, responses):
+        self._queue = [list(r) for r in responses]
+        self.calls = []
+        self.max_speed_hz = 0
+        self.mode = 0
+        self.bits_per_word = 0
+
+    def open(self, bus: int, dev: int) -> None:  # pragma: no cover - no-op
+        self.bus = bus
+        self.dev = dev
+
+    def close(self) -> None:  # pragma: no cover - no-op
+        pass
+
+    def xfer2(self, data):
+        self.calls.append(list(data))
+        if not self._queue:
+            raise AssertionError("Sem resposta configurada para xfer2")
+        return list(self._queue.pop(0))
+
+
+class CNCClientExchangeTests(unittest.TestCase):
+    def _make_client(self, responses):
+        dummy_module = types.SimpleNamespace()
+        dummy_spi = _DummySpi(responses)
+        dummy_module.SpiDev = lambda: dummy_spi
+
+        module_name = CNCClient.__module__
+
+        from unittest.mock import patch
+
+        patcher = patch(f"{module_name}.spidev", dummy_module)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+        client = CNCClient()
+        self.addCleanup(client.close)
+        return client, dummy_spi
+
+    def test_exchange_reads_tail_of_full_dma_frame(self) -> None:
+        request = CNCRequestBuilder.led_control(2, 0x01, 0, 0)
+        dma_frame = _build_spi_dma_frame(request)
+        handshake = [SPI_DMA_HANDSHAKE_READY] * len(dma_frame)
+        payload = [
+            RESP_HEADER,
+            RESP_LED_CTRL,
+            0x02,
+            0x01,
+            0x00,
+            0x00,
+            RESP_TAIL,
+        ]
+        response_frame = [
+            SPI_DMA_HANDSHAKE_READY
+        ] * (SPI_DMA_FRAME_LEN - len(payload)) + payload
+
+        client, spi = self._make_client([handshake, response_frame])
+
+        frame = client.exchange(REQ_LED_CTRL, request, tries=1, settle_delay_s=0.0)
+
+        self.assertEqual(frame, payload)
+        self.assertEqual(len(spi.calls), 2)
+        self.assertEqual(spi.calls[0], dma_frame)
+        self.assertEqual(len(spi.calls[1]), SPI_DMA_FRAME_LEN)
+        self.assertTrue(all(b == 0x00 for b in spi.calls[1]))
+
+    def test_exchange_retries_until_response_is_available(self) -> None:
+        request = CNCRequestBuilder.led_control(3, 0x01, 1, 0)
+        dma_frame = _build_spi_dma_frame(request)
+        handshake = [SPI_DMA_HANDSHAKE_READY] * len(dma_frame)
+        empty_poll = [SPI_DMA_HANDSHAKE_READY] * SPI_DMA_FRAME_LEN
+        payload = [
+            RESP_HEADER,
+            RESP_LED_CTRL,
+            0x03,
+            0x01,
+            0x01,
+            0x00,
+            RESP_TAIL,
+        ]
+        response_frame = [
+            SPI_DMA_HANDSHAKE_READY
+        ] * (SPI_DMA_FRAME_LEN - len(payload)) + payload
+
+        client, spi = self._make_client([handshake, empty_poll, response_frame])
+
+        frame = client.exchange(REQ_LED_CTRL, request, tries=3, settle_delay_s=0.0)
+
+        self.assertEqual(frame, payload)
+        self.assertEqual(len(spi.calls), 3)
+        self.assertEqual(spi.calls[0], dma_frame)
+        self.assertEqual(len(spi.calls[1]), SPI_DMA_FRAME_LEN)
+        self.assertEqual(len(spi.calls[2]), SPI_DMA_FRAME_LEN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/raspberry_spi/test_handshake_validation.py
+++ b/raspberry_spi/test_handshake_validation.py
@@ -12,6 +12,7 @@ if __package__:
         REQ_TAIL,
         SPI_DMA_FRAME_LEN,
         SPI_DMA_HANDSHAKE_BUSY,
+        SPI_DMA_HANDSHAKE_NO_COMM,
         SPI_DMA_HANDSHAKE_READY,
     )
 else:
@@ -24,6 +25,7 @@ else:
         REQ_TAIL,
         SPI_DMA_FRAME_LEN,
         SPI_DMA_HANDSHAKE_BUSY,
+        SPI_DMA_HANDSHAKE_NO_COMM,
         SPI_DMA_HANDSHAKE_READY,
     )
 
@@ -59,6 +61,16 @@ class HandshakeValidationTests(unittest.TestCase):
         msg = str(ctx.exception)
         self.assertIn("preenchimento[0]", msg)
         self.assertIn("0xE1", msg)
+
+    def test_zero_handshake_raises_connection_error(self) -> None:
+        handshake = [SPI_DMA_HANDSHAKE_NO_COMM] * SPI_DMA_FRAME_LEN
+
+        with self.assertRaises(ConnectionError) as ctx:
+            _validate_handshake_frame(self.frame, handshake, len(self.payload))
+
+        msg = str(ctx.exception)
+        self.assertIn("0x00", msg)
+        self.assertIn("Comunicação SPI não ocorreu", msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add explicit constant for the 0x00 SPI handshake value and label it as missing communication
- surface a ConnectionError when the handshake reports no communication instead of ready/busy
- cover the new status handling with unit tests for the SPI handshake validator
- read the full DMA frame while polling the STM32 response so only one RX/TX pair is needed once the reply is ready
- add unit tests that simulate the DMA exchange to ensure the response is extracted from the frame tail

## Testing
- python3 -m unittest discover -s raspberry_spi

------
https://chatgpt.com/codex/tasks/task_e_68d07115ba208326ac98be1bd704d11f