### PR TITLE
Document LED timer limits for low frequencies

### DIFF
--- a/CNC_Controller/App/Inc/Protocol/Requests/led_control_request.h
+++ b/CNC_Controller/App/Inc/Protocol/Requests/led_control_request.h
@@ -10,7 +10,7 @@
 
 typedef struct {
     uint8_t mode;        // Valor conforme LED_MODE_*
-    uint16_t frequency;  // Frequência de pisca em Hz (ignorada salvo modo=BLINK)
+    uint16_t frequency;  // Frequência de pisca em centi-Hz (ignorada salvo modo=BLINK)
 } led_ctrl_channel_cfg_t;
 
 typedef struct {

--- a/CNC_Controller/App/Src/Protocol/Requests/led_control_request.c
+++ b/CNC_Controller/App/Src/Protocol/Requests/led_control_request.c
@@ -2,7 +2,7 @@
 
 // A requisição LED_CTRL (único LED) possui 9 bytes úteis no frame básico:
 // [0]=0xAA, [1]=0x07, [2]=frameId, [3]=ledMask,
-// [4]=LED1.mode, [5..6]=LED1.frequencyHz (BE16, frequência em Hz),
+// [4]=LED1.mode, [5..6]=LED1.frequency (BE16, frequência em centi-Hz),
 // [7]=paridade (XOR dos bytes 1..6), [8]=0x55
 
 #define LED_CTRL_PARITY_LAST_INDEX 6u

--- a/README.md
+++ b/README.md
@@ -51,13 +51,21 @@ Este repositório descreve e implementa um **controlador CNC** baseado no **STM3
 
 **Timers**  
 - **TIM6 — Time Base 50 kHz (DDA/STEP)**: `PSC=79`, `ARR=19`, `Up`, **TRGO=Update** (opcional), **IRQ ON**.  
-- **TIM7 — Time Base 1 kHz (PI/PID)**: `PSC=7999`, `ARR=9`, `Up`, **IRQ ON**.  
-- **TIM2 — Encoder X (32b)**: **Encoder TI1&TI2 (X4)**, `ICxF=0`, `PSC=0`, `ARR=0xFFFFFFFF`.  
-- **TIM5 — Encoder Y (32b)**: igual ao TIM2, `ARR=0xFFFFFFFF`.  
+- **TIM7 — Time Base 1 kHz (PI/PID)**: `PSC=7999`, `ARR=9`, `Up`, **IRQ ON**.
+- **TIM2 — Encoder X (32b)**: **Encoder TI1&TI2 (X4)**, `ICxF=0`, `PSC=0`, `ARR=0xFFFFFFFF`.
+- **TIM5 — Encoder Y (32b)**: igual ao TIM2, `ARR=0xFFFFFFFF`.
 - **TIM3 — Encoder Z (16b)**: **Encoder TI1&TI2 (X4)**, `ICxF=0`, `PSC=0`, `ARR=0xFFFF`.
+- **TIM15 — PWM do LED discreto**: `PSC=0`, `ARR=0xFFFF`. O serviço aceita frequências
+  em centi-hertz e calcula o período em ticks com arredondamento, mas o valor é
+  limitado a 65 536 passos por conta do ARR de 16 bits. Com o clock atual
+  (80 MHz) isso significa que pedidos de 1,00 Hz (`freq_centi_hz = 100`) ou
+  0,20 Hz (`freq_centi_hz = 20`) resultam em 80 M e 400 M ticks, respectivamente,
+  ambos saturados para 0x10000 → ~1,22 kHz efetivos. Para realmente piscar em
+  1 Hz ou 0,2 Hz é necessário reduzir o clock do TIM15 aumentando o prescaler
+  (por exemplo `PSC=7999` → divisor 8 000 → frequência mínima ≈ 0,15 Hz).
 
-**SPI1 (RPi↔STM32)**  
-- **Slave, 8-bit, MODE 3 (CPOL=High, CPHA=2nd)**, **NSS=Hardware Input** (PA4).  
+**SPI1 (RPi↔STM32)**
+- **Slave, 8-bit, MODE 3 (CPOL=High, CPHA=2nd)**, **NSS=Hardware Input** (PA4).
 - **DMA**: RX *Circular* (Byte/Byte, Priority High, inc mem ON), TX *Normal* (Byte/Byte).  
 - **NVIC**: habilite **DMA RX/TX** e **SPI1 global**.
 

--- a/raspberry_spi/README.md
+++ b/raspberry_spi/README.md
@@ -16,8 +16,8 @@ Fiação (Raspberry Pi → STM32 SPI1 Slave)
 - Velocidade sugerida inicial: 1 MHz (ajustável). O firmware usa RX DMA circular.
 
 Uso rápido
-- LED (configura LED1 piscando a 5 Hz, frameId=1):
-  `python3 cnc_spi_client.py led-control --frame-id 1 --mask 0x01 --led1-mode 2 --led1-freq 5`
+- LED (configura LED1 piscando a 0,50 Hz, frameId=1):
+  `python3 cnc_spi_client.py led-control --frame-id 1 --mask 0x01 --led1-mode 2 --led1-freq 0.5`
 
 - Status da fila de movimentos:
   `python3 cnc_spi_client.py queue-status --frame-id 2`

--- a/raspberry_spi/cnc_requests.py
+++ b/raspberry_spi/cnc_requests.py
@@ -52,14 +52,16 @@ class CNCRequestBuilder:
     """Factory centralizada das mensagens enviadas ao STM32."""
 
     @staticmethod
-    def led_control(frame_id: int, led_mask: int, led1_mode: int, led1_freq_hz: int) -> List[int]:
+    def led_control(
+        frame_id: int, led_mask: int, led1_mode: int, led1_freq_centihz: int
+    ) -> List[int]:
         raw = [0] * 9
         raw[0] = REQ_HEADER
         raw[1] = REQ_LED_CTRL
         raw[2] = frame_id & 0xFF
         raw[3] = led_mask & 0xFF
         raw[4] = led1_mode & 0xFF
-        f1_hi, f1_lo = be16_bytes(led1_freq_hz & 0xFFFF)
+        f1_hi, f1_lo = be16_bytes(led1_freq_centihz & 0xFFFF)
         raw[5], raw[6] = f1_hi, f1_lo
         parity_set_byte_1N(raw, 6, 7)
         raw[8] = REQ_TAIL


### PR DESCRIPTION
## Summary
- expand the LED service helper documentation with concrete 1 Hz and 0.2 Hz examples, explaining why the period saturates with the current 80 MHz clock
- update the README timer section to highlight the 16-bit ARR constraint on TIM15 and note the prescaler required to reach sub-hertz blinking

## Testing
- python3 -m unittest discover raspberry_spi

------
https://chatgpt.com/codex/tasks/task_e_68d0e95bb4c48326ae021eeb18ef73c5