### PR TITLE
Handle SPI RX handshake frames without overflow noise

### DIFF
--- a/CNC_Controller/App/Inc/Protocol/router.h
+++ b/CNC_Controller/App/Inc/Protocol/router.h
@@ -44,6 +44,7 @@ void resp_fifo_destroy(response_fifo_t *q);
 int resp_fifo_push(response_fifo_t *q, const uint8_t *frame, uint32_t len);
 // Retira para transmissão (quem chama controla o buffer)
 int resp_fifo_pop(response_fifo_t *q, uint8_t *out, uint32_t max_len);
+int resp_fifo_peek(const response_fifo_t *q, uint8_t *out, uint32_t max_len);
 int resp_fifo_count(const response_fifo_t *q);
 
 #ifdef __cplusplus

--- a/CNC_Controller/App/Src/Protocol/router.c
+++ b/CNC_Controller/App/Src/Protocol/router.c
@@ -213,6 +213,15 @@ int resp_fifo_pop(response_fifo_t *q, uint8_t *out, uint32_t max_len) {
 	free(n);
 	return l;
 }
+int resp_fifo_peek(const response_fifo_t *q, uint8_t *out, uint32_t max_len) {
+	if (!q || !q->head || !out)
+		return 0;
+	if (q->head->len > max_len)
+		return PROTO_ERR_RANGE;
+	memcpy(out, q->head->buf, q->head->len);
+	return (int) q->head->len;
+}
+
 int resp_fifo_count(const response_fifo_t *q) {
 	return q ? q->count : 0;
 }

--- a/CNC_Controller/App/Src/app.c
+++ b/CNC_Controller/App/Src/app.c
@@ -14,6 +14,9 @@
 #define APP_SPI_RX_QUEUE_DEPTH     APP_SPI_DMA_BUF_LEN
 #define APP_SPI_STATUS_READY       0xA5u
 #define APP_SPI_STATUS_BUSY        0x5Au
+
+#define APP_SPI_RX_OVERFLOW_QUEUE_FULL   0x01u
+#define APP_SPI_RX_OVERFLOW_INVALID_FRAME 0x02u
 /* Estados de handshake usam padrões alternados para evitar colisão com 0x00/0xFF. */
 
 #if APP_SPI_DMA_BUF_LEN != 42u
@@ -51,6 +54,10 @@ static volatile uint16_t g_spi_tx_pending_len = 0u;
 static volatile uint8_t g_spi_tx_pending_ready = 0u;
 
 LOG_SVC_DEFINE(LOG_SVC_APP, "app");
+
+#if LOG_ENABLE
+static void app_spi_log_tx_snapshot(uint16_t pending_len);
+#endif
 
 static void app_spi_queue_reset(void);
 static uint8_t app_spi_prime_tx_buffer(uint8_t status);
@@ -154,22 +161,35 @@ void app_poll(void) {
         uint8_t out[APP_SPI_DMA_BUF_LEN];
         int n = resp_fifo_pop(g_resp_fifo, out, sizeof out);
         if (n > 0 && n <= (int)APP_SPI_DMA_BUF_LEN) {
+            uint16_t tx_len = (uint16_t)n;
             uint32_t primask = __get_PRIMASK();
             __disable_irq();
-            memcpy(g_spi_tx_pending_buf, out, (uint32_t)n);
-            g_spi_tx_pending_len = (uint16_t)n;
+            memcpy(g_spi_tx_pending_buf, out, (uint32_t)tx_len);
+            g_spi_tx_pending_len = tx_len;
             g_spi_tx_pending_ready = 1u;
             if (primask == 0u) {
                 __enable_irq();
             }
+#if LOG_ENABLE
+            app_spi_log_tx_snapshot(tx_len);
+#endif
         } else if (n == PROTO_ERR_RANGE) {
             LOGT_THIS(LOG_STATE_ERROR, PROTO_ERR_RANGE, "spi_tx", "resp too large for dma frame");
         }
     }
 
     if (g_spi_rx_overflow) {
+        uint8_t overflow_reason = g_spi_rx_overflow;
         g_spi_rx_overflow = 0u;
-        LOGT_THIS(LOG_STATE_ERROR, PROTO_WARN, "spi_rx", "overflow");
+
+        const char *reason_label = "unknown";
+        if (overflow_reason == APP_SPI_RX_OVERFLOW_QUEUE_FULL) {
+            reason_label = "queue_full";
+        } else if (overflow_reason == APP_SPI_RX_OVERFLOW_INVALID_FRAME) {
+            reason_label = "invalid_frame";
+        }
+
+        LOGT_THIS(LOG_STATE_ERROR, PROTO_WARN, "spi_rx", "overflow reason=%s", reason_label);
     }
 }
 
@@ -196,6 +216,70 @@ int app_resp_push(const uint8_t *frame, uint32_t len) {
     }
     return resp_fifo_push(g_resp_fifo, frame, len);
 }
+
+#if LOG_ENABLE
+static void app_spi_format_hex(const uint8_t *buf, uint32_t len,
+                               char *dst, size_t dst_len) {
+    size_t pos = 0u;
+
+    if (dst_len == 0u) {
+        return;
+    }
+
+    dst[0] = '\0';
+
+    for (uint32_t i = 0u; i < len && (pos + 2u) < dst_len; ++i) {
+        int written = snprintf(&dst[pos], dst_len - pos, "%02X", (unsigned int)buf[i]);
+        if (written < 0) {
+            dst[0] = '\0';
+            return;
+        }
+        if ((size_t)written >= dst_len - pos) {
+            dst[dst_len - 1u] = '\0';
+            return;
+        }
+        pos += (size_t)written;
+        if ((i + 1u) < len && (pos + 1u) < dst_len) {
+            dst[pos++] = ' ';
+            dst[pos] = '\0';
+        }
+    }
+}
+
+static void app_spi_log_tx_snapshot(uint16_t pending_len) {
+    if (pending_len > APP_SPI_DMA_BUF_LEN) {
+        pending_len = APP_SPI_DMA_BUF_LEN;
+    }
+
+    uint8_t current_buf[APP_SPI_DMA_BUF_LEN];
+    memset(current_buf, APP_SPI_STATUS_READY, sizeof current_buf);
+    memcpy(current_buf, g_spi_tx_pending_buf, pending_len);
+
+    uint8_t next_buf[APP_SPI_DMA_BUF_LEN];
+    memset(next_buf, APP_SPI_STATUS_READY, sizeof next_buf);
+
+    int next_len = 0;
+    if (g_resp_fifo) {
+        next_len = resp_fifo_peek(g_resp_fifo, next_buf, sizeof next_buf);
+        if (next_len == PROTO_ERR_RANGE) {
+            LOGA_THIS(LOG_STATE_ERROR, PROTO_ERR_RANGE, "spi_tx", "next resp exceeds dma frame");
+            next_len = 0;
+        }
+    }
+
+    if (next_len > 0 && next_len < (int)APP_SPI_DMA_BUF_LEN) {
+        memset(&next_buf[next_len], APP_SPI_STATUS_READY,
+               (size_t)(APP_SPI_DMA_BUF_LEN - (uint32_t)next_len));
+    }
+
+    char current_hex[((size_t)APP_SPI_DMA_BUF_LEN * 3u) + 1u];
+    char next_hex[((size_t)APP_SPI_DMA_BUF_LEN * 3u) + 1u];
+    app_spi_format_hex(current_buf, APP_SPI_DMA_BUF_LEN, current_hex, sizeof current_hex);
+    app_spi_format_hex(next_buf, APP_SPI_DMA_BUF_LEN, next_hex, sizeof next_hex);
+
+    LOGA_THIS(LOG_STATE_APPLIED, PROTO_OK, "spi_tx", "now=%s next=%s", current_hex, next_hex);
+}
+#endif
 
 static void app_spi_queue_reset(void) {
     __disable_irq();
@@ -412,38 +496,41 @@ static int app_spi_queue_pop(app_spi_frame_t *out) {
  *     posterior. O retorno de erro desta etapa cobre a validação de limites da
  *     fila circular (profundidade e comprimento máximo do quadro). Se a fila
  *     estiver cheia ou o quadro for inválido, a flag de overflow é acionada.
- *  4. Atualiza o status do handshake para READY quando há dados em fila, ou
- *     mantém BUSY para forçar o mestre a repetir a leitura até que a fila
- *     aceite um novo quadro.
- *  5. Reinicia o DMA com o status apropriado para dar sequência ao ciclo de
+ *  4. Quando nenhum quadro válido é identificado, diferencia entre um ciclo de
+ *     handshake (ausência de header) — que apenas mantém o status calculado a
+ *     partir da ocupação atual da fila — e um frame inválido (header presente
+ *     sem tail), o qual é sinalizado como overflow para análise.
+ *  5. Atualiza o status do handshake: permanece em BUSY em caso de overflow ou
+ *     calcula dinamicamente (READY/BUSY) com base na ocupação da fila quando o
+ *     fluxo está consistente.
+ *  6. Reinicia o DMA com o status apropriado para dar sequência ao ciclo de
  *     comunicação SPI.
  * Variáveis locais:
  *  - offset: posição inicial do quadro válido dentro do buffer DMA.
  *  - len: comprimento do quadro localizado; auxilia na validação de tamanho.
- *  - armazenado: indica se o quadro foi efetivamente enfileirado, controlando
- *                a escolha do status (READY/BUSY) pós-processamento.
+ *  - overflow_reason: registra o motivo do overflow (fila cheia ou frame
+ *                     inválido) para repasse ao laço principal de logging.
  */
 static void app_spi_handle_txrx_complete(void) {
     uint16_t offset = 0u;
     uint16_t len = 0u;
-    uint8_t armazenado = 0u;
+    uint8_t overflow_reason = 0u;
 
     app_spi_invalidate_dcache(g_spi_rx_dma_buf, APP_SPI_DMA_BUF_LEN);
 
     if (app_spi_locate_frame(g_spi_rx_dma_buf, &offset, &len) == 0) {
-        if (app_spi_queue_push_isr(&g_spi_rx_dma_buf[offset], len) == 0) {
-            armazenado = 1u;
-        } else {
-            g_spi_rx_overflow = 1u;
+        if (app_spi_queue_push_isr(&g_spi_rx_dma_buf[offset], len) != 0) {
+            overflow_reason = APP_SPI_RX_OVERFLOW_QUEUE_FULL;
         }
-    } else {
-        g_spi_rx_overflow = 1u;
+    } else if (memchr(g_spi_rx_dma_buf, REQ_HEADER, APP_SPI_DMA_BUF_LEN) != NULL) {
+        overflow_reason = APP_SPI_RX_OVERFLOW_INVALID_FRAME;
     }
 
-    if (armazenado) {
-        g_spi_next_status = app_spi_compute_status();
-    } else {
+    if (overflow_reason != 0u) {
+        g_spi_rx_overflow = overflow_reason;
         g_spi_next_status = APP_SPI_STATUS_BUSY;
+    } else {
+        g_spi_next_status = app_spi_compute_status();
     }
 
     app_spi_restart_dma(g_spi_next_status);


### PR DESCRIPTION
## Summary
- treat zero-filled SPI polls as handshake cycles by checking for request headers before flagging overflow, keeping the DMA restart status driven by the RX queue occupancy
- tag RX overflow causes so the main loop logs whether the queue filled or an invalid frame was observed

## Testing
- not run (STM32 firmware build/tests not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d487d63c888326aea1b43c9bea7f5d