### PR TITLE
Prevent BUSY handshake byte preceding SPI responses

### DIFF
--- a/CNC_Controller/App/Src/app.c
+++ b/CNC_Controller/App/Src/app.c
@@ -172,9 +172,8 @@ void app_poll(void) {
             uint32_t primask = __get_PRIMASK();
             __disable_irq();
             memset(g_spi_tx_pending_buf, 0, APP_SPI_DMA_BUF_LEN);
-            uint16_t pad = (uint16_t)(APP_SPI_DMA_BUF_LEN - (uint16_t)n);
-            memcpy(&g_spi_tx_pending_buf[pad], out, (uint32_t)n);
-            g_spi_tx_pending_len = (uint16_t)APP_SPI_DMA_BUF_LEN;
+            memcpy(g_spi_tx_pending_buf, out, (uint32_t)n);
+            g_spi_tx_pending_len = (uint16_t)n;
             g_spi_tx_pending_ready = 1u;
             if (primask == 0u) {
                 __enable_irq();
@@ -266,8 +265,22 @@ static uint8_t app_spi_prime_tx_buffer(uint8_t status) {
         __enable_irq();
     }
 
+    uint8_t primed_status = status;
+    if (has_pending && pending_len > 0u) {
+        /*
+         * Ao injetar um payload de resposta no quadro atual, o mestre espera
+         * encontrar imediatamente o header 0xAB ao iniciar a próxima enquete.
+         * Mesmo que o laço principal tenha reservado BUSY para o próximo
+         * ciclo (por exemplo, durante o half-transfer do DMA), o fato de já
+         * existir um frame pronto indica que estamos aptos a responder.
+         * Forçar READY evita que o byte 0 (preenchimento) herde 0x5A e o host
+         * interprete erroneamente a resposta como "ocupado" antes do header.
+         */
+        primed_status = APP_SPI_STATUS_READY;
+    }
+
     app_spi_handshake_prime_args_t args = {
-        .status_byte = status,
+        .status_byte = primed_status,
         .tx_buf = g_spi_tx_dma_buf,
         .tx_len = APP_SPI_DMA_BUF_LEN,
         .response_buf = has_pending ? pending_copy : NULL,
@@ -356,8 +369,19 @@ static void app_spi_try_commit_pending_to_active(void) {
         return;
     }
 
+    uint8_t primed_status = status_byte;
+    if (pending_len > 0u) {
+        /*
+         * O canal possui uma resposta pronta e ainda não transmitiu nenhum
+         * byte desta rodada. Ao sinalizar READY garantimos que o preenchimento
+         * no início do quadro seja zerado, impedindo que o mestre observe
+         * 0x5A (BUSY) antes do header 0xAB ao efetuar o polling.
+         */
+        primed_status = APP_SPI_STATUS_READY;
+    }
+
     app_spi_handshake_prime_args_t args = {
-        .status_byte = status_byte,
+        .status_byte = primed_status,
         .tx_buf = g_spi_tx_dma_buf,
         .tx_len = APP_SPI_DMA_BUF_LEN,
         .response_buf = pending_copy,

--- a/CNC_Controller/App/Src/app_spi_handshake.c
+++ b/CNC_Controller/App/Src/app_spi_handshake.c
@@ -10,18 +10,15 @@ uint8_t app_spi_handshake_compute_status(uint8_t queue_count,
 
 /*
  * A rotina abaixo encapsula a preparação do buffer DMA utilizado no
- * handshaking SPI. Quando não há payload pendente ela preenche todos os 42
- * bytes com o status de READY/BUSY, preservando o comportamento clássico do
- * protocolo. Assim que um serviço enfileira uma resposta, o conteúdo é
- * alinhado à direita e preenchido com zeros à esquerda antes do DMA ser
- * iniciado. Esse alinhamento garante que os bytes de "READY" (0xA5) ou
- * "BUSY" (0x5A) não vazem para o início da mensagem — exatamente o efeito
- * observado pelo usuário quando o primeiro byte chegava como 0x5A. O mestre
- * Raspberry Pi envia 0x3C ao pesquisar por respostas pendentes e espera que
- * qualquer payload sobrescreva completamente o preenchimento de status. Com a
- * reformulação, assim que a fila fica vazia voltamos a transmitir apenas o
- * padrão READY, enquanto respostas reais ocupam o final do quadro com zeros à
- * esquerda, como requerido.
+ * handshaking SPI. Sem payload pendente ela preenche todos os 42 bytes com o
+ * status de READY/BUSY, preservando o comportamento clássico do protocolo.
+ * Quando uma resposta é disponibilizada pelos serviços, o conteúdo é copiado
+ * a partir da posição zero do quadro, mantendo o header 0xAB no primeiro byte
+ * observado pelo mestre. O restante do buffer permanece preenchido com o
+ * padrão de status informado (tipicamente READY uma vez que existe payload).
+ * Dessa forma evitamos que 0x5A (BUSY) anteceda o header durante o polling,
+ * ao mesmo tempo em que preservamos o comportamento histórico de preencher o
+ * espaço não utilizado com o handshake vigente.
  */
 app_spi_handshake_prime_result_t
 app_spi_handshake_prime(const app_spi_handshake_prime_args_t *args) {
@@ -48,11 +45,7 @@ app_spi_handshake_prime(const app_spi_handshake_prime_args_t *args) {
         if (args->response_len <= args->tx_len &&
             (result.state == APP_SPI_HANDSHAKE_STATE_READY ||
              result.state == APP_SPI_HANDSHAKE_STATE_BUSY)) {
-            uint32_t pad = args->tx_len - args->response_len;
-            if (pad > 0u) {
-                memset(args->tx_buf, 0, pad);
-            }
-            memcpy(&args->tx_buf[pad], args->response_buf, args->response_len);
+            memcpy(args->tx_buf, args->response_buf, args->response_len);
             result.consumed_response = 1u;
             result.state = APP_SPI_HANDSHAKE_STATE_RESPONSE;
         } else {


### PR DESCRIPTION
## Summary
- stage pending service responses using their real length so the DMA payload begins at byte zero
- update the SPI handshake priming helper to copy responses from offset zero while leaving unused bytes filled with the READY pattern

## Testing
- python3 -m pytest raspberry_spi/test_handshake_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68d6acdc33588326aa259b57bc18f490