### PR TITLE
Disable automatic boot hello frame and document opt-in behaviour

### DIFF
--- a/CNC_Controller/App/Src/app.c
+++ b/CNC_Controller/App/Src/app.c
@@ -10,6 +10,10 @@
 #include "Services/Test/test_spi_service.h"
 #include "app_spi_handshake.h"
 
+#ifndef APP_ENABLE_BOOT_TEST_RESPONSES
+#define APP_ENABLE_BOOT_TEST_RESPONSES 0
+#endif
+
 extern DMA_HandleTypeDef hdma_spi1_tx;
 
 #define APP_SPI_RX_QUEUE_DEPTH     APP_SPI_DMA_BUF_LEN
@@ -152,7 +156,16 @@ void app_init(void) {
         g_spi_need_restart = 1u;
     }
 
+#if APP_ENABLE_BOOT_TEST_RESPONSES
+    /*
+     * Opcionalmente publica o frame de teste "hello" ao inicializar para
+     * depuração do enlace.  Mantemos o envio desabilitado por padrão para não
+     * interferir nas primeiras respostas reais do protocolo (por exemplo,
+     * "led-control"), já que o mestre interpreta qualquer byte diferente de
+     * 0xA5 como início de payload.
+     */
     (void)test_spi_send_hello();
+#endif
 }
 
 void app_poll(void) {

--- a/raspberry_spi/README.md
+++ b/raspberry_spi/README.md
@@ -34,9 +34,11 @@ Uso rápido
   `python3 cnc_spi_client.py hello`
   (envia `AA 68 65 6C 6C 6F 55` e aguarda `AB 68 65 6C 6C 6F 54`)
 
-- Frame de boot "hello":
+- (Opcional) Frame de boot "hello" — disponível apenas quando o firmware é
+  compilado com `APP_ENABLE_BOOT_TEST_RESPONSES=1`:
   `python3 cnc_spi_client.py boot-hello --tries 10 --chunk-len 7`
-  (espera-se o frame `AB 68 65 6C 6C 6F 54` com header/tail válidos)
+  (por padrão o firmware não enfileira mais esse frame automaticamente para
+  evitar que respostas reais sejam precedidas por dados de teste)
 
 - Lista resumida com exemplos (sem necessidade de SPI ativo):
   `python3 cnc_spi_client.py examples`

--- a/raspberry_spi/cnc_commands.py
+++ b/raspberry_spi/cnc_commands.py
@@ -163,19 +163,33 @@ class CNCCommandExecutor:
             print(decoded.get("payload"))
 
     def boot_hello(self, args: argparse.Namespace) -> None:
-        frame, stats = self.client.read_boot_hello_info(
-            tries=args.tries,
-            settle_delay_s=args.settle_delay,
-            chunk_len=args.chunk_len,
-        )
+        try:
+            frame, stats = self.client.read_boot_hello_info(
+                tries=args.tries,
+                settle_delay_s=args.settle_delay,
+                chunk_len=args.chunk_len,
+            )
+        except TimeoutError:
+            print(
+                "Frame 'hello' não encontrado. Ative APP_ENABLE_BOOT_TEST_RESPONSES "
+                "no firmware ou utilize o comando 'hello'."
+            )
+            return
         print_boot_frame_info(frame, stats)
 
     def boot_led(self, args: argparse.Namespace) -> None:
-        frame, stats = self.client.read_boot_led_info(
-            tries=args.tries,
-            settle_delay_s=args.settle_delay,
-            chunk_len=args.chunk_len,
-        )
+        try:
+            frame, stats = self.client.read_boot_led_info(
+                tries=args.tries,
+                settle_delay_s=args.settle_delay,
+                chunk_len=args.chunk_len,
+            )
+        except TimeoutError:
+            print(
+                "Frame 'led' não encontrado. Certifique-se de que o firmware "
+                "publica esse frame de boot antes de usar este comando."
+            )
+            return
         print_boot_frame_info(frame, stats)
 
 

--- a/raspberry_spi/cnc_spi_client.py
+++ b/raspberry_spi/cnc_spi_client.py
@@ -173,7 +173,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     boot_hello = sub.add_parser(
         "boot-hello",
-        help="Ler frame de teste 'hello' enfileirado automaticamente no boot",
+        help=(
+            "Ler frame de teste 'hello' enfileirado automaticamente no boot "
+            "(quando habilitado no firmware)"
+        ),
     )
     _common_args(boot_hello, include_tries=True, default_tries=16)
     boot_hello.add_argument("--chunk-len", type=int, default=7)
@@ -182,7 +185,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     led_boot = sub.add_parser(
         "led",
-        help="Ler frame de teste 'led' do STM32 (enfileirado no boot)",
+        help=(
+            "Ler frame de teste 'led' do STM32 (enfileirado no boot quando "
+            "habilitado)"
+        ),
     )
     _common_args(led_boot, include_tries=True, default_tries=16)
     led_boot.add_argument("--chunk-len", type=int, default=7)
@@ -222,11 +228,11 @@ def print_examples(_: argparse.Namespace) -> None:
         ),
         ("Requisição 'hello'", f"{base_cmd} hello --tries 5"),
         (
-            "Frame de boot 'hello'",
+            "Frame de boot 'hello' (requer firmware com boot-test habilitado)",
             f"{base_cmd} boot-hello --tries 10 --chunk-len 7",
         ),
         (
-            "Frame de boot 'led'",
+            "Frame de boot 'led' (requer firmware com boot-test habilitado)",
             f"{base_cmd} led --tries 10 --chunk-len 7",
         ),
     ]


### PR DESCRIPTION
## Summary
- gate the boot "hello" test frame behind the APP_ENABLE_BOOT_TEST_RESPONSES flag so normal replies are not preceded by test data
- document the optional boot frame behaviour and adjust the SPI client tooling to handle disabled boot-test responses gracefully

## Testing
- python3 -m compileall raspberry_spi

------
https://chatgpt.com/codex/tasks/task_e_68d727f70948832686d5e2be86515d28