### PR TITLE
Permitir configurar ou desativar o byte de polling SPI

### DIFF
--- a/Docs/explicacao_ultimo_commit.md
+++ b/Docs/explicacao_ultimo_commit.md
@@ -1,0 +1,49 @@
+# Explicação do commit "Delay SPI DMA restart until payload is ready"
+
+Este documento resume, em português, as alterações introduzidas pelo commit que
+adiou a reativação do DMA de SPI até que o firmware tenha preparado um payload
+de resposta.
+
+## Problema observado
+
+Quando o Raspberry Pi concluía o primeiro ciclo de transmissão (42 bytes) com o
+STM32, ele precisava efetuar um segundo ciclo idêntico para finalmente receber a
+resposta real. O motivo era que o firmware reiniciava o DMA de transmissão
+imediatamente após concluir uma transferência, antes que o serviço responsável
+pela resposta tivesse carregado os dados no buffer. Como consequência, o STM32
+retornava apenas o padrão de handshake `0xA5`, forçando o mestre a executar uma
+nova rodada de polling para então obter o payload válido.
+
+## Estratégia adotada
+
+O commit introduziu um mecanismo simples de "adiamento" (defer) que segura a
+reinicialização do DMA por um ciclo de `app_poll` assim que uma requisição é
+processada. Enquanto a flag de defer estiver ativa, o firmware espera que o
+serviço produtor de resposta preencha um buffer pendente. Assim que o buffer é
+preparado (ou, no máximo, após um pequeno timeout de segurança), o DMA é
+reativado já com o payload real, eliminando a necessidade da segunda rodada de
+42 bytes.
+
+## Principais mudanças no código
+
+- Foram adicionados buffers e flags auxiliares (`g_spi_tx_pending_buf`,
+  `g_spi_tx_pending_ready`, `g_spi_restart_defer`, entre outros) para armazenar o
+  payload pronto e indicar quando o DMA pode ser religado.【F:CNC_Controller/App/Src/app.c†L50-L78】
+- A função `app_spi_try_commit_pending_to_active` agora copia o conteúdo do
+  buffer pendente para o buffer DMA ativo somente quando há payload disponível,
+  limpando simultaneamente a flag de defer.【F:CNC_Controller/App/Src/app.c†L362-L433】
+- `app_poll` passou a chamar a rotina de commit antes e depois de alimentar o
+  roteador, garantindo que qualquer resposta enfileirada seja promovida ao DMA
+  o quanto antes.【F:CNC_Controller/App/Src/app.c†L183-L217】
+- Ao detectar o fim de uma transferência (`app_spi_handle_txrx_complete`), o
+  firmware marca que um restart é necessário, mas delega à rotina de defer a
+  decisão de quando reiniciar o DMA, respeitando a janela em que o payload é
+  preparado.【F:CNC_Controller/App/Src/app.c†L638-L683】
+
+## Resultado esperado
+
+Com essa abordagem, o STM32 já começa a preparar o payload real durante a
+janela do handshake `0xA5`. Dessa forma, quando o Raspberry Pi inicia o próximo
+ciclo de 42 bytes com o padrão `0x3C`, o firmware responde imediatamente com os
+bytes efetivos do serviço solicitado, sem precisar de uma repetição extra.
+

--- a/raspberry_spi/README.md
+++ b/raspberry_spi/README.md
@@ -34,9 +34,11 @@ Uso rápido
   `python3 cnc_spi_client.py hello`
   (envia `AA 68 65 6C 6C 6F 55` e aguarda `AB 68 65 6C 6C 6F 54`)
 
-- Frame de boot "hello":
+- (Opcional) Frame de boot "hello" — disponível apenas quando o firmware é
+  compilado com `APP_ENABLE_BOOT_TEST_RESPONSES=1`:
   `python3 cnc_spi_client.py boot-hello --tries 10 --chunk-len 7`
-  (espera-se o frame `AB 68 65 6C 6C 6F 54` com header/tail válidos)
+  (por padrão o firmware não enfileira mais esse frame automaticamente para
+  evitar que respostas reais sejam precedidas por dados de teste)
 
 - Lista resumida com exemplos (sem necessidade de SPI ativo):
   `python3 cnc_spi_client.py examples`
@@ -44,6 +46,8 @@ Uso rápido
 Parâmetros comuns
 - `--bus` (padrão 0) e `--dev` (padrão 0) selecionam `/dev/spidev<bus>.<dev>`.
 - `--speed` em Hz (padrão 1_000_000).
+- `--poll-byte` altera o byte usado durante o polling (padrão 0x3C). Use `--disable-poll`
+  para confiar apenas no frame de handshake (útil para testes específicos).
 
 Notas de protocolo
 - Requests: header `0xAA`, tail `0x55`.
@@ -54,7 +58,9 @@ Notas de protocolo
   - Start/End/Queue-Status-Req/FPGA-Status-Req não possuem campo de paridade (4 bytes)
 
 Limitações e dicas
-- O STM32 é escravo: para “ouvir” uma resposta é necessário gerar clock no master (RPi). O cliente envia `0x3C` em todos os bytes durante esse polling, evitando colisão com o header `0xAA` dos requests.
+- O STM32 é escravo: para “ouvir” uma resposta é necessário gerar clock no master (RPi).
+  Por padrão, o cliente envia `0x3C` em todos os bytes durante esse polling (configurável
+  via `--poll-byte`), evitando colisão com o header `0xAA` dos requests.
 - Caso o serviço no firmware ainda não publique respostas, um timeout pode ocorrer.
 - Comandos com resposta aguardam, por padrão, até 5 polls (`--tries`) com
   atraso de 1 ms (`--settle-delay`). Se o firmware demorar mais para responder,


### PR DESCRIPTION
## Summary
- adicionar parsing de byte e flags globais no CLI para permitir escolher o byte de polling ou desativá-lo
- propagar a escolha para o cliente SPI, validando respostas já presentes no handshake e permitindo desativar o polling
- documentar no README as novas opções de linha de comando relacionadas ao polling

## Testing
- python3 -m compileall raspberry_spi

------
https://chatgpt.com/codex/tasks/task_e_68d727f70948832686d5e2be86515d28