### PR TITLE
Ensure SPI handshake uses 20-byte payload window

### DIFF
--- a/CNC_Controller/App/Inc/app_spi_handshake.h
+++ b/CNC_Controller/App/Inc/app_spi_handshake.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 #define APP_SPI_MAX_REQUEST_LEN 42u
+#define APP_SPI_MAX_RESPONSE_LEN 20u
 #define APP_SPI_DMA_BUF_LEN   APP_SPI_MAX_REQUEST_LEN
 
 #define APP_SPI_STATUS_READY 0xA5u

--- a/CNC_Controller/App/Src/app_spi_handshake.c
+++ b/CNC_Controller/App/Src/app_spi_handshake.c
@@ -10,18 +10,19 @@ uint8_t app_spi_handshake_compute_status(uint8_t queue_count,
 
 /*
  * A rotina abaixo encapsula a preparação do buffer DMA utilizado no
- * handshaking SPI. Quando não há payload pendente ela preenche todos os 42
- * bytes com o status de READY/BUSY, preservando o comportamento clássico do
- * protocolo. Assim que um serviço enfileira uma resposta, o conteúdo é
- * alinhado à direita e preenchido com zeros à esquerda antes do DMA ser
- * iniciado. Esse alinhamento garante que os bytes de "READY" (0xA5) ou
- * "BUSY" (0x5A) não vazem para o início da mensagem — exatamente o efeito
- * observado pelo usuário quando o primeiro byte chegava como 0x5A. O mestre
- * Raspberry Pi envia 0x3C ao pesquisar por respostas pendentes e espera que
- * qualquer payload sobrescreva completamente o preenchimento de status. Com a
- * reformulação, assim que a fila fica vazia voltamos a transmitir apenas o
- * padrão READY, enquanto respostas reais ocupam o final do quadro com zeros à
- * esquerda, como requerido.
+ * handshaking SPI. O quadro de 42 bytes é zerado e reservamos sempre os 20
+ * bytes finais (APP_SPI_MAX_RESPONSE_LEN) para transportar o status
+ * READY/BUSY ou um frame de resposta. Assim que um serviço enfileira uma
+ * resposta, o conteúdo é alinhado à direita e preenchido com zeros à esquerda
+ * antes do DMA ser iniciado. Esse alinhamento garante que os bytes de
+ * "READY" (0xA5) ou "BUSY" (0x5A) permaneçam confinados ao final do quadro,
+ * deixando os 22 bytes iniciais como `0x00`, exatamente como o usuário
+ * solicitou. O mestre Raspberry Pi envia 0x3C ao pesquisar por respostas
+ * pendentes e espera que qualquer payload sobrescreva completamente o
+ * preenchimento de status. Com a reformulação, assim que a fila fica vazia
+ * voltamos a transmitir apenas o padrão READY/BUSY concentrado na janela de
+ * 20 bytes, enquanto respostas reais ocupam o final do quadro com zeros à
+ * esquerda.
  */
 app_spi_handshake_prime_result_t
 app_spi_handshake_prime(const app_spi_handshake_prime_args_t *args) {
@@ -34,7 +35,12 @@ app_spi_handshake_prime(const app_spi_handshake_prime_args_t *args) {
         return result;
     }
 
-    memset(args->tx_buf, args->status_byte, args->tx_len);
+    memset(args->tx_buf, 0, args->tx_len);
+
+    uint16_t window_len =
+        (args->tx_len > APP_SPI_MAX_RESPONSE_LEN) ? APP_SPI_MAX_RESPONSE_LEN
+                                                  : args->tx_len;
+    uint16_t window_offset = args->tx_len - window_len;
 
     if (args->status_byte == APP_SPI_STATUS_READY) {
         result.state = APP_SPI_HANDSHAKE_STATE_READY;
@@ -45,13 +51,10 @@ app_spi_handshake_prime(const app_spi_handshake_prime_args_t *args) {
     }
 
     if (args->response_buf && args->response_len > 0u) {
-        if (args->response_len <= args->tx_len &&
+        if (args->response_len <= window_len &&
             (result.state == APP_SPI_HANDSHAKE_STATE_READY ||
              result.state == APP_SPI_HANDSHAKE_STATE_BUSY)) {
             uint32_t pad = args->tx_len - args->response_len;
-            if (pad > 0u) {
-                memset(args->tx_buf, 0, pad);
-            }
             memcpy(&args->tx_buf[pad], args->response_buf, args->response_len);
             result.consumed_response = 1u;
             result.state = APP_SPI_HANDSHAKE_STATE_RESPONSE;
@@ -59,6 +62,9 @@ app_spi_handshake_prime(const app_spi_handshake_prime_args_t *args) {
             result.state = APP_SPI_HANDSHAKE_STATE_UNRECOGNIZED;
             result.consumed_response = 0u;
         }
+    } else if (result.state == APP_SPI_HANDSHAKE_STATE_READY ||
+               result.state == APP_SPI_HANDSHAKE_STATE_BUSY) {
+        memset(&args->tx_buf[window_offset], args->status_byte, window_len);
     }
 
     return result;


### PR DESCRIPTION
## Summary
- zero the SPI DMA buffer before priming to guarantee a leading 0x00 padding region
- reserve the final 20 bytes for READY/BUSY or response payloads using the new APP_SPI_MAX_RESPONSE_LEN constant

## Testing
- not run (reason: no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68dd58b30eac83269b3a92656d52ddcb